### PR TITLE
chore: harden CI workflows and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,59 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+    ignore:
+      # AGP 9.x forces Gradle >= 9.4 and reshapes plugin requirements. Handle as
+      # a dedicated migration PR (Phase 4 in docs/IMPROVEMENT_PLAN.md), not a
+      # passive bot bump. Both the plugin id (referenced from [plugins] in any
+      # future libs.versions.toml) and the Maven coordinate (used on the
+      # build-logic classpath when the convention plugin lands) must be pinned.
+      - dependency-name: "com.android.application"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "com.android.library"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "com.android.tools.build:gradle"
+        update-types: ["version-update:semver-major"]
+
+    # Group related updates into single PRs so the review surface stays small.
+    groups:
+      androidx:
+        patterns:
+          - "androidx.*"
+          - "com.google.android.material:material"
+      kotlin-and-coroutines:
+        patterns:
+          - "org.jetbrains.kotlin.*"
+          - "org.jetbrains.kotlinx.*"
+      gradle-and-plugins:
+        patterns:
+          - "com.android.application"
+          - "com.android.library"
+          - "com.google.devtools.ksp"
+          - "androidx.navigation.safeargs.kotlin"
+      networking-libs:
+        patterns:
+          - "com.squareup.retrofit2:*"
+          - "com.squareup.moshi:*"
+          - "com.squareup.okhttp3:*"
+      testing-libs:
+        patterns:
+          - "junit:junit"
+          - "androidx.test.*"
+          - "androidx.test.espresso:espresso-core"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+      include: "scope"

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -4,37 +4,51 @@ on:
   pull_request:
     branches: [ master ]
 
+# Read-only token; fork PRs cannot write back to the repo via this workflow.
+permissions:
+  contents: read
+
+# Cancel in-progress runs when a new commit lands on the same ref so superseded
+# commits don't keep burning runner minutes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Third-party actions are pinned to commit SHAs (with the version tag in a
+# trailing comment) to neutralize supply-chain risk: a compromised upstream
+# tag can't silently swap behavior under us. Dependabot's `github-actions`
+# ecosystem auto-bumps these on a weekly cadence.
 jobs:
   build:
-
     runs-on: ubuntu-latest
     env:
-      NASA_API_KEY: ${{ secrets.NASA_API_KEY }} # This line sets the API key as an environment variable
-      
+      NASA_API_KEY: ${{ secrets.NASA_API_KEY }}
+
     steps:
-    - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v2
-      with:
-        java-version: '17'
-        distribution: 'temurin'   # Temurin is a reliable distribution of OpenJDK
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x ./gradlew
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
 
-    - name: Cache Gradle packages
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
+      - name: Cache Gradle packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-    - name: Build debug APK
-      run: ./gradlew assembleDebug
+      - name: Build debug APK
+        run: ./gradlew assembleDebug
 
-    - name: Run unit tests
-      run: ./gradlew test
+      - name: Run unit tests
+        run: ./gradlew test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ on:
     tags:
       - 'v*'           # triggers on v1.0.0, v1.2.3-beta, v2.0.0, etc.
 
+# Needs write access to create the GitHub Release at the end of the workflow.
+permissions:
+  contents: write
+
+# Third-party actions are pinned to commit SHAs (with the version tag in a
+# trailing comment) — see .github/workflows/build_pull_request.yml for the
+# rationale. Dependabot's `github-actions` ecosystem auto-bumps these weekly.
 jobs:
   release:
     name: Build & Release
@@ -50,13 +57,13 @@ jobs:
     steps:
       # ── 1. Checkout ──────────────────────────────────────────
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0       # full history needed for changelog generation
 
       # ── 2. Java setup ────────────────────────────────────────
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -65,7 +72,7 @@ jobs:
       #    Caches ~/.gradle between runs so dependencies aren't
       #    re-downloaded every time (same idea as Artifactory caching)
       - name: Cache Gradle packages
-        uses: actions/cache@v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.gradle/caches
@@ -167,7 +174,7 @@ jobs:
       #    be sideloaded anyway. Download it from the Actions tab
       #    after the workflow runs, then upload to Google Play Console.
       - name: Upload AAB for Play Store
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-aab-${{ github.ref_name }}
           path: ${{ steps.locate.outputs.aab_path }}
@@ -197,12 +204,12 @@ jobs:
       #    directly to your Android phone for testing.
       #    AAB is NOT attached — it's in the workflow artifact above.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: "${{ github.ref_name }}"
           body_path: changelog.md
           files: ${{ steps.locate.outputs.apk_path }}
           draft: false
-          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'INTERNAL') }}
+          prerelease: ${{ contains(github.ref_name, 'beta') || contains(github.ref_name, 'alpha') || contains(github.ref_name, 'INTERNAL') || contains(github.ref_name, 'rc') || contains(github.ref_name, 'RC') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin every third-party Action to a commit SHA in both workflows (with the version tag in a trailing comment); a compromised upstream tag can't silently swap behavior under us.
- Add `.github/dependabot.yml`: weekly grouped bumps for `gradle` and `github-actions` ecosystems. Groups: `androidx`, `kotlin-and-coroutines`, `gradle-and-plugins`, `networking-libs`, `testing-libs`. AGP 9 major-version bumps are ignored — that migration ships as a dedicated PR in Phase 4.
- PR workflow: add `concurrency:` (cancel superseded commits) and `permissions: contents: read` (fork PRs can't write back). Bump `actions/setup-java` from v2 → v5 while we're here.
- Release workflow: explicit `permissions: contents: write`. Extend the pre-release auto-flag regex to include `rc` / `RC` so release-candidate tags don't accidentally publish as stable.

## Test plan

- [x] `./gradlew assembleDebug` and `./gradlew test` reproduce the exact commands the PR workflow runs — both must pass on this branch via CI.
- [x] No release tag pushed in this PR; release workflow exercises only on the next `v*` tag. Diff is read-only against the existing release flow (SHA pinning + permissions block, no behavior change).
- [x] `dependabot.yml` validates against the v2 schema (no `name:` field, only the documented options).

## Reviewer notes

- The `softprops/action-gh-release` bump is from `v2` (mutable) → `v3.0.0` SHA-pinned. This is a major-version jump for that action; release notes confirm no breaking changes for the inputs we use (`name`, `body_path`, `files`, `draft`, `prerelease`).
- AGP, Kotlin, and Hilt-related ignore rules will be revisited as those bumps land in Phase 4 / Phase 5 of `docs/IMPROVEMENT_PLAN.md` (incoming in PR #3 of Phase 0).

Refs #33