### PR TITLE
docs: add IMPROVEMENT_PLAN and update CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,130 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project context
+
+Asteroid Radar is a Play-Store-published Android app (internal track) tracking NASA Near Earth Objects. Single-module, view-system UI (Fragments + Data Binding + Navigation), offline-first via Room, daily background refresh via WorkManager. Default package is `com.tarek.asteroidradar`.
+
+**Roadmap and ongoing improvements** live in [`docs/IMPROVEMENT_PLAN.md`](docs/IMPROVEMENT_PLAN.md) — phased modernization (Gradle Kotlin DSL → convention plugin → quality tooling → toolchain bump → Hilt → R8 → tests + Kover). Check it before starting non-trivial work; PRs should reference the relevant phase.
+
+## Build, test, run
+
+Single-module Android Gradle project. JDK 17, Kotlin 1.6.21, AGP 8.3.0, `compileSdk`/`targetSdk` 35, `minSdk` 26.
+
+```bash
+./gradlew assembleDebug          # debug APK
+./gradlew assembleRelease        # signed release APK (needs keystore env vars, see below)
+./gradlew bundleRelease          # signed AAB for Play Store
+./gradlew test                   # all unit tests (JVM)
+./gradlew connectedAndroidTest   # instrumented tests (needs device/emulator)
+
+# Run a single unit test class or method
+./gradlew :app:testDebugUnitTest --tests "com.tarek.asteroidradar.ExampleUnitTest"
+./gradlew :app:testDebugUnitTest --tests "com.tarek.asteroidradar.ExampleUnitTest.someMethod"
+```
+
+There is no separate lint step in CI; use `./gradlew lint` locally if needed.
+
+## Required configuration
+
+`app/build.gradle` reads these from env vars first, then falls back to `local.properties`:
+
+- `NASA_API_KEY` — required for both debug and release; injected as `BuildConfig.NASA_API_KEY`.
+- `KEYSTORE_PATH`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD` — required only when running `assembleRelease` / `bundleRelease`. The keystore must be PKCS12 (`storeType "PKCS12"` is hard-coded in `signingConfigs.release`).
+
+`local.properties` is gitignored; do not commit secrets there to git.
+
+## Versioning and tags
+
+Version is computed in `app/build.gradle` from four fields at the top:
+
+```
+versionMajor / versionMinor / versionPatch / versionClassifier
+versionCode = minSdk*1_000_000 + major*10_000 + minor*100 + patch
+versionName = "<major>.<minor>.<patch>-<classifier>"
+```
+
+Bump these — not `versionCode`/`versionName` directly — when cutting a release.
+
+SemVer with this app-shipped lens:
+
+| Bump | When |
+|---|---|
+| **MAJOR** (`vX.0.0`) | Breaking for users — `minSdk` bump, complete UI rewrite, removed feature, or a toolchain migration that forces every fork to follow (Kotlin major, AGP major, etc.) |
+| **MINOR** (`v1.X.0`) | New user-visible feature (a new filter, a new screen, new data source) |
+| **PATCH** (`v1.0.X`) | Bug fixes, dep bumps, internal refactor — most Phase 0–3 PRs land as PATCH |
+
+The classifier suffix maps cleanly to Play tracks:
+
+| Classifier | Play track |
+|---|---|
+| `-INTERNAL` | Internal testing |
+| `-ALPHA` | Closed alpha |
+| `-BETA` | Open beta |
+| `-RC` | Production rollout candidate |
+| (none) / `-RELEASE` | Production |
+
+**Conventions:**
+
+- Tag at phase boundaries from `docs/IMPROVEMENT_PLAN.md`, not arbitrarily.
+- Every tag is a GitHub Release with auto-generated notes (the existing release workflow handles this).
+- Tag names containing `INTERNAL`, `alpha`, `beta`, `rc`, or `RC` auto-flag as pre-release.
+
+`.github/workflows/release.yml` runs on tags matching `v*`:
+
+1. **Validates** that `vMAJOR.MINOR.PATCH` (classifier ignored) matches `versionMajor/Minor/Patch` in `app/build.gradle`. Mismatch fails the workflow before building. Always update `build.gradle` and commit before tagging.
+2. Runs unit tests, decodes `KEYSTORE_BASE64` to a temp `.jks`, builds signed APK + AAB.
+3. Attaches the APK to the GitHub Release; uploads the AAB as a workflow artifact (Play Store uploads are manual).
+
+Required GitHub secrets: `KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`, `NASA_API_KEY`.
+
+PRs targeting `master` run `.github/workflows/build_pull_request.yml` (`assembleDebug` + `test`). Both workflows pin third-party Actions to commit SHAs (with the version tag in a trailing comment); Dependabot's `github-actions` ecosystem auto-bumps them weekly.
+
+## Branching, commits, issues
+
+- **Branches** — `feat/<slug>`, `fix/<slug>`, `chore/<slug>`, `docs/<slug>`, `ci/<slug>`, `build/<slug>`, `refactor/<slug>`, `test/<slug>`, `perf/<slug>`. Match the Conventional Commits prefixes.
+- **Commits** — [Conventional Commits](https://www.conventionalcommits.org/) prefixes (`feat:`, `fix:`, `chore:`, `docs:`, `ci:`, `build:`, `test:`, `refactor:`, `perf:`).
+- **Issues first** — every non-trivial change opens a GitHub issue first. The PR body uses `Fixes #N` (auto-closes the issue on merge) or `Refs #N` (cross-links without closing). Doc/typo/dep-bump PRs are exempt.
+- **One scope per PR.** Phase 0 ships as three small PRs, not one mega-diff. Same pattern through the roadmap.
+- **Merge** — squash-merge by default; delete the branch on merge so the active-branches list stays scannable.
+
+## Recommended Claude Code skills
+
+Google maintains official AI-optimized skills for Android at <https://github.com/android/skills>. Skills relevant to this project's roadmap:
+
+| Skill | Use when |
+|---|---|
+| [`r8-analyzer`](https://github.com/android/skills) | Phase 6 (R8 enablement, ProGuard keep rules) |
+| [`edge-to-edge`](https://github.com/android/skills) | Phase 8 (edge-to-edge adoption) |
+| [`jetpack-compose`](https://github.com/android/skills) | Phase 9 (Compose migration), if/when it's pulled forward |
+| [`agp-9-upgrade`](https://github.com/android/skills) | When AGP 9 lands as a dedicated migration |
+| [`navigation`](https://github.com/android/skills) | If revisiting Navigation safe-args setup |
+
+Skills are not vendored — install locally when starting the matching phase.
+
+## Architecture
+
+Standard offline-first Android architecture inside one package `com.tarek.asteroidradar`:
+
+```
+domain/      — plain Kotlin models exposed to UI (Asteroid, PictureOfDay)
+network/     — Retrofit service, DTOs, Moshi setup, JSON parsing helpers
+database/    — Room entities, DAO, AsteroidDatabase singleton via getDatabase()
+repository/  — AsteroidRepository: single source of truth, mediates network ↔ DB
+work/        — RefreshDataWorker (CoroutineWorker) for background refresh
+ui/main/     — MainFragment + MainViewModel + AsteroidAdapter
+ui/detail/   — DetailFragment
+util/        — BindingAdapters, Constants
+AsteroidRadarApplication.kt, MainActivity.kt
+```
+
+Key flows worth knowing before editing:
+
+- **Data flow.** UI observes `LiveData` from `AsteroidRepository.getAsteroidSelection(filter)`, which reads from Room via `AsteroidDao`. Network refresh is a separate write-only path (`refreshAsteroids()` → DAO `insertAll`). The repo never returns network data directly; the DB is the source of truth. `AsteroidsFilter` is a sealed class (`TODAY` / `WEEK` / `STORED`) and the DAO has one query per case — when adding a filter, add a DAO query, a sealed subclass, and a branch in `getAsteroidSelection`.
+- **Two API endpoints, two response shapes.** `neo/rest/v1/feed` returns a JSON string parsed manually (`parseAsteroidsJsonResult` in `network/NetworkUtils.kt`) because of its nested-by-date structure; `planetary/apod` is decoded by Moshi. Both go through one Retrofit instance using a custom `HandleScalarAndJsonConverterFactory` in `network/service.kt` that picks the converter from `@ScalarResponse` / `@JsonResponse` annotations on each service method. Adding a new endpoint means tagging it with one of those annotations.
+- **Background refresh.** `AsteroidRadarApplication.onCreate()` enqueues a unique periodic `RefreshDataWorker` (1 day, `ExistingPeriodicWorkPolicy.KEEP`) gated on unmetered network + charging + battery-not-low + device-idle. The worker calls `deletePastAsteroids()` then `refreshAsteroids()`. `MainViewModel.init` also triggers a refresh on launch — keep both paths idempotent.
+- **DB singleton.** `getDatabase()` in `database/AsteroidDatabase.kt` uses a `lateinit` global plus `synchronized` block. There is no DI framework; `MainViewModel` and `RefreshDataWorker` both call `getDatabase(context)` directly. `MainViewModel` is constructed via its inner `Factory` in `MainFragment`.
+- **Data Binding + custom adapters.** `buildFeatures.dataBinding = true`. Layouts call into `util/BindingAdapters.kt` (e.g. image loading via Picasso, asteroid status icons). When changing UI bindings, check there first before adding new logic in fragments.
+- **KSP, not kapt, for Room.** Room compiler runs through KSP (`com.google.devtools.ksp`); generated sources are added to `main` via `sourceSets { main { java { srcDir 'build/generated/ksp/src/main/kotlin' } } }`. `kotlin-kapt` is still applied but isn't currently used by any processor.
+- **Navigation safe-args** is enabled (`androidx.navigation.safeargs.kotlin`) — pass arguments between `MainFragment` and `DetailFragment` through the generated `*Directions` / `*Args` classes rather than raw bundles.

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -1,0 +1,241 @@
+# AsteroidRadar improvement plan
+
+Asteroid Radar is a Play-Store-published Android app (internal track). This
+document is the living roadmap for modernizing it from "works for me" to "easy
+to extend, easy to test, painless to release." Phases are independently
+shippable; pick them off in order — each one stacks on the last.
+
+## Status at a glance
+
+| Phase | Theme | State |
+|---|---|---|
+| 0 | Repo hygiene (Dependabot, CI hardening, README, this doc) | **In progress** |
+| 1 | Gradle Kotlin DSL + version catalog | Pending |
+| 2 | Convention plugin (`build-logic/`) | Pending |
+| 3 | Code-quality plumbing (Spotless / Detekt / Lint) | Pending |
+| 4 | Toolchain modernization (Kotlin 2.x, AndroidX bumps, Picasso → Coil) | Pending |
+| 5 | Hilt | Pending |
+| 6 | Production hardening (R8, fail-fast on missing API key) | Pending |
+| 7 | Tests + Kover | Pending |
+| 8 | Edge-to-edge | Pending |
+| 9 | Compose migration | Deferred |
+| — | **Module split** lands with feature #2, not as a phase | — |
+
+Tick the table when phases land. Each phase below lists scope, rationale, and
+the rough size; sub-bullets are the concrete deltas.
+
+## Versioning and tags
+
+Tag/release policy lives in [`CLAUDE.md`](../CLAUDE.md#versioning-and-tags).
+Cut a tag at every phase boundary — don't accumulate three phases into one
+release. Phase 0 lands as a PATCH (`v1.3.6-INTERNAL`). The toolchain bump in
+Phase 4 is breaking for any fork (Kotlin major, dependency replacements) and
+ships as MAJOR (`v2.0.0-INTERNAL`).
+
+---
+
+## Phase 0 — Repo hygiene (in progress)
+
+Goal: get the meta-paperwork into shape before touching the build. Skipped
+ConsultMe-style community files (CONTRIBUTING / SECURITY / Code of Conduct /
+issue + PR templates) — solo project, not worth the surface area.
+
+Three small PRs:
+
+- **CI hardening + Dependabot** — pin third-party Action SHAs in both
+  workflows, add weekly grouped Dependabot for `gradle` + `github-actions`
+  ecosystems, add `concurrency:` + `permissions: contents: read` to the PR
+  workflow, explicit `permissions: contents: write` on release. AGP 9 majors
+  pinned in Dependabot until Phase 4 / a dedicated migration. Extend the
+  pre-release auto-flag to include `rc` / `RC`.
+- **README rewrite** — replace the 10-line "use this Gradle wrapper" note
+  with: tagline + status badges, features, tech-stack table, build/run, the
+  `local.properties` template (`NASA_API_KEY` + four keystore vars + the
+  PKCS12 store-type constraint), release flow, classifier-to-Play-track table.
+- **`docs/IMPROVEMENT_PLAN.md` + `CLAUDE.md` update** — this document; plus
+  CLAUDE.md gains the project-context note, refactored "Versioning and tags"
+  section with the SemVer table and Play-track mapping, branching/commits
+  conventions, and a "Recommended Claude Code skills" pointer.
+
+## Phase 1 — Gradle Kotlin DSL + version catalog
+
+Goal: kill stringly-typed Groovy build scripts; centralize versions.
+
+Modexa "[7 Gradle Kotlin DSL Tricks](https://medium.com/@Modexa/7-gradle-kotlin-dsl-tricks-for-human-friendly-builds-68506270906f)" tricks 1, 3, 4, 6, 7 apply directly:
+
+- **Trick 1: Version Catalog** — new `gradle/libs.versions.toml` with
+  `[versions]`, `[libraries]`, `[bundles]`, `[plugins]`. Single source of
+  truth for every dependency.
+- **Trick 3: Type-safe project accessors** —
+  `enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")` in
+  `settings.gradle.kts`. `project(":app")` becomes `projects.app`. Cheap to
+  enable now even with one module; pays off as soon as a second module lands.
+- **Trick 4: Lazy task APIs** — convert any `tasks.create(...)` to
+  `tasks.register(...)`. The existing `copyDependencyLibs` task is already
+  lazy; this is mostly a check.
+- **Trick 6: Bundles** — `[bundles]` for lifecycle libs (lifecycle-viewmodel,
+  lifecycle-livedata, lifecycle-runtime + fragment-ktx) and the testing libs
+  group (junit, androidx-test-ext, espresso-core).
+- **Trick 7: Helper functions** — extract the env-var-or-`local.properties`
+  fallback into a typed `env()` helper instead of inlining
+  `System.getenv("X") ?: localProperties['X'].toString()` four times.
+
+Module conversions:
+- `build.gradle` → `build.gradle.kts` (root)
+- `settings.gradle` → `settings.gradle.kts`
+- `app/build.gradle` → `app/build.gradle.kts`
+- Update Gradle wrapper to a Kotlin-DSL-friendly modern version (Gradle 8.10+).
+
+## Phase 2 — Convention plugin (`build-logic/`)
+
+Goal: move Android/Kotlin/SDK/signing config out of the module script and into
+a precompiled script plugin so adding a feature module is near-one-liner.
+
+- New `build-logic/` included build with one plugin:
+  `asteroidradar.android.application` — composes AGP-app + kotlin-android +
+  kotlin-parcelize + safe-args + KSP plugin application; sets
+  compileSdk/minSdk/targetSdk; JVM 17 toolchain; release/debug build types;
+  signing config; data binding + buildConfig.
+- Shared helpers (`configureKotlinAndroid`, `configureBuildFeatures`) in a
+  Kotlin sources module.
+- `app/build.gradle.kts` shrinks to plugin application + `namespace` +
+  module-specific dependencies.
+
+The feature-module convention plugins (`*.android.library`, `*.android.compose`,
+`*.android.hilt`) get added when their respective phases land — Hilt in Phase 5,
+Compose in Phase 9 if it happens.
+
+## Phase 3 — Code-quality plumbing
+
+Goal: enforce formatting, static analysis, and lint in CI before tests run.
+
+- **Spotless** — ktlint integration + license-header check that **preserves
+  the existing MIT block** (don't rewrite to ConsultMe's `// Copyright $YEAR
+  MyCompany` literal). Apply to `*.kt` and `*.gradle.kts`.
+- **Detekt** — config in `config/detekt.yml`. Stricter rules can ratchet up
+  later; start with the upstream defaults plus a few opt-ins.
+- **Android Lint** — set `checkReleaseBuilds = true`, generate
+  `app/lint-baseline.xml`. Regenerate per module via
+  `./gradlew :<module>:updateLintBaseline` rather than hand-editing.
+- **CI ordering** — `spotlessCheck` → `detekt` → `lintRelease` → `test` →
+  `assembleDebug`. Fast checks first so signal arrives early.
+- Upload lint + test reports as workflow artifacts on every run (with
+  `if: always()` so failures still surface them).
+
+## Phase 4 — Toolchain modernization
+
+The chunky one. Touches every dependency declaration; one PR, one device-tested
+release. Tag this as `v2.0.0-INTERNAL` — breaking for any fork.
+
+- **Kotlin 1.6.21 → 2.0.x** (or current stable). 1.6 is from 2022 and blocks
+  modern AndroidX bumps.
+- **Coroutines 1.6.4 → 1.8.x.**
+- **AndroidX bumps** — lifecycle 2.8+, fragment 1.8+, navigation 2.8+,
+  work-runtime 2.10+, room 2.7+ (already 2.6). Activity 1.10+.
+- **Picasso → Coil 2.x.** Picasso last released in 2018; Coil is the modern
+  Kotlin-native equivalent and works fine in the view system. Update
+  `BindingAdapters.kt` to use Coil's `load()` extension.
+- **Drop `kotlin-kapt` plugin application** — KSP is the only annotation
+  processor in this project (Room). The kapt plugin is currently applied but
+  unused.
+- Verify the app still works end-to-end on a device: NeoWs feed loads, APOD
+  loads, filter switching works, background WorkManager triggers a refresh.
+
+## Phase 5 — Hilt
+
+Goal: introduce DI before feature work starts so feature modules slot in with
+`@HiltViewModel` / `@AndroidEntryPoint` already wired.
+
+- New convention plugin `asteroidradar.android.hilt` adds the hilt-gradle +
+  ksp plugins, `enableAggregatingTask = true`, `hilt-android` impl, and
+  `hilt-compiler` ksp.
+- `AsteroidRadarApplication` gets `@HiltAndroidApp`.
+- `MainActivity` + `MainFragment` + `DetailFragment` get `@AndroidEntryPoint`.
+- `MainViewModel` becomes `@HiltViewModel` with constructor-injected
+  `AsteroidRepository`. Its inner `Factory` class goes away.
+- `RefreshDataWorker` becomes `@HiltWorker` with constructor-injected
+  repository; the manual `getDatabase(context)` + repository construction
+  goes away.
+- The `getDatabase()` global singleton in `database/AsteroidDatabase.kt` gets
+  replaced by a `@Provides @Singleton` in a Hilt `Module`.
+- Hilt 2.51+ requires Kotlin 2.0+, which is why this phase comes after the
+  toolchain bump.
+
+## Phase 6 — Production hardening
+
+Goal: a release build should fail fast on missing config, and ship a real
+minified APK.
+
+- `minifyEnabled true` + `shrinkResources true` for the release build type
+  (currently `minifyEnabled false`).
+- Slim starter `proguard-rules.pro` — `-keepattributes
+  SourceFile,LineNumberTable` + `-renamesourcefileattribute SourceFile` so
+  production crashes symbolicate via the AGP-emitted `mapping.txt`. AAR-shipped
+  consumer rules from Hilt, Room, Retrofit, Moshi cover the rest. Adopters add
+  reflective-keeps on demand. Use the [`r8-analyzer`](https://github.com/android/skills)
+  Claude Code skill for keep-rule debugging.
+- **Fail-fast on missing API key in release.** Currently a blank
+  `NASA_API_KEY` in release results in a runtime 403 rather than a build
+  failure. Add a check in the release build type's `buildConfigField` wiring.
+- Lint baseline regenerated post-toolchain-bump (Phase 4 will likely surface
+  new warnings).
+
+## Phase 7 — Tests + Kover
+
+Goal: replace the empty `Example*Test` shells with real coverage that doubles
+as documentation for "how to test in this repo."
+
+- **Kover plugin** in the convention plugin so every module is instrumented
+  by default. Aggregate task: `./gradlew koverHtmlReport`. CI uploads the
+  HTML + XML reports as artifacts (XML for any future Codecov/SonarCloud).
+- **No coverage gate at first.** After 2–3 PRs of real tests, set a soft
+  floor via `koverVerify` (start at 60%, ratchet up).
+- **Real tests to write:**
+  - `parseAsteroidsJsonResult` parser tests — feed it sample NeoWs payloads
+    incl. edge cases (missing fields, empty date buckets).
+  - `AsteroidDao` integration test using in-memory Room — `getAsteroids`,
+    `getTodayAsteroids`, `getWeeklyAsteroids`, `deletePreviousAsteroid`.
+  - `AsteroidRepository.getAsteroidSelection` filter mapping with a fake DAO.
+  - `MainViewModel` state transitions with Turbine + MockK + Truth.
+- Add bundle in `libs.versions.toml`: `test-shared` re-exports junit,
+  truth, mockk, turbine, coroutines-test, androidx-test-ext, espresso-core.
+
+## Phase 8 — Edge-to-edge
+
+Goal: opt into edge-to-edge layouts. Modern Android (16+) effectively requires
+this. The official [`edge-to-edge`](https://github.com/android/skills) Claude
+Code skill is a ready-made adoption guide — install when this phase starts.
+
+- `MainActivity.onCreate` calls `WindowCompat.setDecorFitsSystemWindows(window,
+  false)`.
+- Status-bar / navigation-bar colors via theme attributes.
+- Insets handled in fragment root layouts via `OnApplyWindowInsetsListener` or
+  the AndroidX insets-compat APIs.
+
+## Phase 9 — Compose migration (deferred)
+
+Goal: rewrite the UI in Jetpack Compose. Tracked here so it's not forgotten;
+**not committed to** as a near-term phase. View system + Data Binding works
+fine for this app and the migration is a several-PR effort.
+
+If/when it happens: introduce the `asteroidradar.android.compose` convention
+plugin, migrate `DetailFragment` first (simpler), then `MainFragment`. Use the
+[`jetpack-compose`](https://github.com/android/skills) Claude Code skill.
+
+## Quality bets to consider (no phase yet)
+
+- **`dependency-analysis-android-gradle-plugin`** — flag unused / misplaced
+  dependencies. Highest signal once we have multiple modules.
+- **Baseline profiles + a macrobenchmark module** for cold-start
+  performance. Worthwhile after Phase 5 / Hilt landed (DI graph affects
+  startup).
+- **Gradle build scans** if a Develocity instance becomes available.
+- **Jacoco merge** — alternative coverage backend if Kover blocks on a Kotlin
+  bump.
+
+## How to use this document
+
+When starting a phase, change its row in the status table to **In progress**,
+link the issue/PR, and update sub-bullets with checkboxes if it helps. When
+merged, mark **Done** with the PR number. The point is to keep the next-best
+action obvious to whoever opens the repo a month from now (often: future-you).


### PR DESCRIPTION
## Summary

Two new docs that future-me will read first when picking the repo back up:

- **`docs/IMPROVEMENT_PLAN.md`** — phased modernization roadmap. Phase 0 hygiene → Phase 1 Gradle Kotlin DSL + version catalog → Phase 2 convention plugin (`build-logic/`) → Phase 3 Spotless/Detekt/Lint → Phase 4 toolchain bump (Kotlin 2.x, AndroidX, Picasso → Coil) → Phase 5 Hilt → Phase 6 R8 → Phase 7 tests + Kover → Phase 8 edge-to-edge → Phase 9 Compose (deferred). Module split happens with feature #2, not as a phase. Skips ConsultMe-style community files (CONTRIBUTING / SECURITY / CoC / templates) because this is a solo project.
- **`CLAUDE.md` update** — adds a project-context note linking to the plan; merges the prior "Versioning" + "Releases" into one "Versioning and tags" section with the SemVer table and the classifier-to-Play-track mapping (incl. the new `rc` / `RC` pre-release flag from #34); adds a "Branching, commits, issues" section that formalizes Conventional Commits + the issue-first workflow; adds a "Recommended Claude Code skills" pointer at <https://github.com/android/skills>.

Mirrors the structure ConsultMe uses (`docs/IMPROVEMENT_PLAN.md` as the living roadmap, `CLAUDE.md` for orientation), adapted for a shipped Play Store app rather than a template.

## Test plan

- [x] Markdown renders without broken internal links — every relative path (`CLAUDE.md`, `../CLAUDE.md`, `.github/workflows/release.yml`) resolves on this branch.
- [x] No code or workflow files touched; CI is the same `assembleDebug` + `test` run as before.
- [x] Cross-references between the two files are consistent (CLAUDE.md → `docs/IMPROVEMENT_PLAN.md`, IMPROVEMENT_PLAN.md → `../CLAUDE.md#versioning-and-tags`).

## Reviewer notes

- Stacks on top of #34 (CI hardening) and #36 (README rewrite), but doesn't depend on either being merged first — the docs cross-link to existing files and a forward-pointer to this PR's path.
- `.gitignore` entries for `app/release/` and `.claude/` are intentionally not included — those are housekeeping noise that deserves a separate one-line PR after this lands.
- The "Recommended Claude Code skills" table lists skills to install **locally** when their phase begins. Skills aren't vendored into the repo.

Refs #37