### PR TITLE
chore: gitignore .claude and app/release artifact dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -204,3 +204,10 @@ fabric.properties
 # End of https://www.toptal.com/developers/gitignore/api/androidstudio,kotlin,macos
 /app/config/
 /.idea/
+
+# Claude Code per-project settings (local to each developer's workspace).
+.claude/
+
+# AGP release artifacts (baselineProfiles, output-metadata.json) emitted
+# outside the standard app/build/ tree.
+/app/release/


### PR DESCRIPTION
## Summary

Add two entries to `.gitignore` so the local-only artifact directories stop showing up as untracked on every `git status`:

- **`.claude/`** — Claude Code's per-project settings (`settings.local.json`).
- **`/app/release/`** — AGP-emitted release-build artifacts (baselineProfiles, output-metadata.json) outside `app/build/`.

## Test plan

- [x] `git status` is clean on this branch with both directories present locally.
- [x] No tracked files affected (the two paths were untracked the whole time).

Fixes #49