### PR TITLE
build: add asteroidradar.android.application convention plugin

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,16 +29,12 @@
 
 import java.util.Properties
 
-// Plugin order matters: kotlin-android must be applied before
-// androidx.navigation.safeargs.kotlin (the safe-args plugin checks for the
-// kotlin plugin during apply and fails fast otherwise).
+// All plugin application + SDK levels + JVM toolchain + default test runner
+// + buildConfig flag come from the convention plugin in `build-logic/`. Only
+// app-specific config stays here (namespace, applicationId, version, signing,
+// buildTypes, sourceSets, dataBinding).
 plugins {
-    alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
-    alias(libs.plugins.kotlin.parcelize)
-    alias(libs.plugins.ksp)
-    alias(libs.plugins.androidx.navigation.safeargs)
+    id("asteroidradar.android.application")
 }
 
 // Version components — bump these (not versionCode / versionName directly) when
@@ -49,10 +45,10 @@ val versionMinor = 3
 val versionPatch = 5
 val versionClassifier = "INTERNAL"
 
-// SDK levels. Hoisted as named vals so they're easy to grep / bump.
-val asteroidMinSdk = 26
-val asteroidTargetSdk = 35
-val asteroidCompileSdk = 35
+// versionCode formula uses minSdk as a high digit so a future minSdk bump
+// auto-pushes versionCode forward without colliding with prior releases.
+// Mirrors the value the convention plugin sets for `defaultConfig.minSdk`.
+val versionCodeMinSdk = 26
 
 // Modexa trick #7: read "X from environment, falling back to local.properties"
 // was inlined four times in the Groovy script. Centralized here so adding a new
@@ -67,18 +63,14 @@ fun env(name: String, default: String = ""): String =
 
 android {
     namespace = "com.tarek.asteroidradar"
-    compileSdk = asteroidCompileSdk
 
     defaultConfig {
         applicationId = "com.tarek.asteroidradar"
-        minSdk = asteroidMinSdk
-        targetSdk = asteroidTargetSdk
-        versionCode = asteroidMinSdk * 1_000_000 +
+        versionCode = versionCodeMinSdk * 1_000_000 +
             versionMajor * 10_000 +
             versionMinor * 100 +
             versionPatch
         versionName = "$versionMajor.$versionMinor.$versionPatch-$versionClassifier"
-        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     signingConfigs {
@@ -123,17 +115,7 @@ android {
     }
 
     buildFeatures {
-        buildConfig = true
         dataBinding = true
-    }
-
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 }
 

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -1,0 +1,46 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+plugins {
+    `kotlin-dsl`
+}
+
+// Match the project JVM toolchain so the precompiled-script-plugin classes
+// load under the same Java version the rest of the build uses.
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+// `implementation` (not `compileOnly`) because precompiled script plugins
+// resolve `id("com.android.application")` from the convention plugin's own
+// runtime classpath at apply time — `compileOnly` would satisfy the
+// type-safe-accessor compile step but leave Gradle unable to find the
+// plugin when a consuming module applies it. The AGP / Kotlin / KSP /
+// safe-args artifacts must be on `implementation` here.
+dependencies {
+    implementation(libs.android.gradle.plugin)
+    implementation(libs.kotlin.gradle.plugin)
+    implementation(libs.ksp.gradle.plugin)
+    implementation(libs.androidx.navigation.safeargs.gradle.plugin)
+}

--- a/build-logic/convention/src/main/kotlin/asteroidradar.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/asteroidradar.android.application.gradle.kts
@@ -1,0 +1,69 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import com.android.build.api.dsl.ApplicationExtension
+
+// Composed conventions for any Android application module. SDK / JVM / plugin
+// application lives here so feature module #2 can opt in with
+// `plugins { id("asteroidradar.android.application") }` and skip 30 lines of
+// boilerplate. Module-specific config (namespace, applicationId, version,
+// signing, buildTypes, sourceSets, dataBinding) stays in the consuming script.
+//
+// Plugin order matters: kotlin-android must precede
+// androidx.navigation.safeargs.kotlin (safe-args fails fast otherwise).
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.kapt")
+    id("org.jetbrains.kotlin.plugin.parcelize")
+    id("com.google.devtools.ksp")
+    id("androidx.navigation.safeargs.kotlin")
+}
+
+extensions.configure<ApplicationExtension> {
+    compileSdk = 35
+
+    defaultConfig {
+        minSdk = 26
+        targetSdk = 35
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    buildFeatures {
+        buildConfig = true
+    }
+}
+
+// `kotlinOptions` lives on the Kotlin plugin extension, not the Android one;
+// configure it via the project's `tasks.withType<KotlinCompile>()` API so this
+// works on Kotlin 1.6.x as well as later majors that move toward
+// `compilerOptions {}`. Phase 4's Kotlin bump can swap this out cleanly.
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).configureEach {
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+}

--- a/build-logic/settings.gradle.kts
+++ b/build-logic/settings.gradle.kts
@@ -1,0 +1,42 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+    // Re-import the root project's version catalog so `libs.<...>` aliases
+    // resolve identically inside the convention plugin's classpath. Without
+    // this `from(files(...))` block, the included build wouldn't see the
+    // catalog (Gradle keeps catalogs scoped to a single build by default).
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}
+
+rootProject.name = "build-logic"
+include(":convention")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,6 +70,15 @@ androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", vers
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }
 junit = { module = "junit:junit", version.ref = "junit" }
 
+# Gradle-plugin Maven coordinates — used by the build-logic convention plugins
+# (compileOnly classpath) so they can apply plugins by id. Versions are
+# intentionally `version.ref`'d to the same refs used in [plugins] above so
+# there's no opportunity for plugin id ↔ classpath drift.
+android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
+ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
+androidx-navigation-safeargs-gradle-plugin = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "androidxNavigation" }
+
 [bundles]
 # Lifecycle-related libs that travel together (Modexa trick #6). When adding a
 # new lifecycle-runtime-ktx in Phase 4, append to this bundle rather than the

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,6 +28,12 @@
  */
 
 pluginManagement {
+    // Convention plugins live in `build-logic/`. Registering it here (rather
+    // than as a top-level `includeBuild`) means its precompiled script plugins
+    // are resolvable from any module's `plugins {}` block via
+    // `id("asteroidradar.android.application")`.
+    includeBuild("build-logic")
+
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Summary

Phase 2 of [`docs/IMPROVEMENT_PLAN.md`](https://github.com/Tarek-Bohdima/AsteroidRadar/blob/master/docs/IMPROVEMENT_PLAN.md#phase-2--convention-plugin-build-logic). Move the duplicate-able config out of `app/build.gradle.kts` so feature module #2 starts with `plugins { id("asteroidradar.android.application") }` and skips ~30 lines of boilerplate.

**What lives in the convention plugin** (one place, every Android application module):
- AGP application + kotlin-android + kotlin-kapt + parcelize + KSP + safe-args plugin application (in the same order the app module needed — kotlin-android before safe-args).
- `compileSdk = 35`, `minSdk = 26`, `targetSdk = 35`.
- `compileOptions` + Kotlin `jvmTarget` = 17.
- `defaultConfig.testInstrumentationRunner`.
- `buildFeatures.buildConfig = true`.

**What stays in `app/build.gradle.kts`** (per-module, not duplicate-able):
- `namespace`, `applicationId`.
- `versionMajor` / `versionMinor` / `versionPatch` / `versionClassifier` (release.yml greps these by name).
- `signingConfigs.release` and the `env(name)` helper for keystore/API-key secrets.
- `buildTypes` (debug / release `buildConfigField` for `NASA_API_KEY`).
- `androidResources.generateLocaleConfig`.
- `buildFeatures.dataBinding` (only the application module has DataBinding-driven layouts; future library modules likely won't).
- KSP-generated source-set wiring.
- `dependencies { ... }`.

`app/build.gradle.kts` shrunk from 162 → 134 lines. The split keeps reach low (only 28 lines moved) but pre-pays the right way for Phase 5's Hilt convention plugin and any feature module split.

## Layout

- `build-logic/settings.gradle.kts` — included build; reimports the root version catalog via `from(files("../gradle/libs.versions.toml"))` so `libs.<...>` aliases resolve identically inside the convention plugin's classpath.
- `build-logic/convention/build.gradle.kts` — `kotlin-dsl` + JVM 17 toolchain. Gradle-plugin Maven artifacts on `implementation` (not `compileOnly` — see "Reviewer notes").
- `build-logic/convention/src/main/kotlin/asteroidradar.android.application.gradle.kts` — the precompiled script plugin.

`gradle/libs.versions.toml` gains `[libraries]` entries for the gradle-plugin Maven coordinates of AGP, Kotlin, KSP, and safe-args. All `version.ref`'d to the same refs already used in `[plugins]`, so plugin id ↔ classpath version can't drift.

`settings.gradle.kts` registers the included build via `pluginManagement { includeBuild("build-logic") }`.

## Test plan

- [x] `./gradlew help` resolves clean (validates settings + plugin discovery).
- [x] `./gradlew assembleDebug` builds `app/build/outputs/apk/debug/app-debug.apk`.
- [x] `./gradlew test` — ExampleUnitTest passes (the only one currently).
- [x] CI on this PR runs the same `assembleDebug` + `test` chain — must stay green.

## Reviewer notes

- **`implementation` vs `compileOnly`** — first attempt used `compileOnly`, which compiles fine but fails at apply time with `Plugin [id: 'com.android.application'] was not found`. Precompiled script plugins resolve `id("...")` from the convention plugin's own **runtime** classpath at apply time; `compileOnly` doesn't satisfy that. Switching to `implementation` is the standard pattern (used in nowinandroid and Google's Android samples). The "compileOnly" advice in some older docs assumes a `pluginManagement.plugins { id(...) version "..." }` block declaring versions in the consuming `settings.gradle.kts` — `implementation` here is simpler and self-contained for an `includeBuild`.
- **`kotlinOptions.jvmTarget`** in the precompiled script is set via `tasks.withType<KotlinCompile> { kotlinOptions { ... } }` rather than the Android `kotlinOptions { ... }` DSL block. The Android DSL accessor isn't generated for precompiled script plugins on Kotlin 1.6.21; the task-graph approach works on every Kotlin major and Phase 4's bump can swap it to `compilerOptions {}`.
- **No `library` / `compose` / `hilt` plugin variants here** — only added when the matching phase / use case lands (Phase 5 for Hilt; Phase 9 if/when Compose comes; library variant when feature module #2 lands).

Fixes #53