### PR TITLE
ci: add Detekt static analysis with baseline

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -52,6 +52,12 @@ jobs:
         # build steps so missing header or wrong indent fails fast.
         run: ./gradlew spotlessCheck
 
+      - name: Run Detekt
+        # Static analysis (cyclomatic complexity, magic numbers, naming, etc.).
+        # Existing violations are baselined in `config/detekt/baseline.xml`;
+        # new code is checked against defaults + `config/detekt.yml`.
+        run: ./gradlew detekt
+
       - name: Build debug APK
         run: ./gradlew assembleDebug
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.androidx.navigation.safeargs) apply false
+    alias(libs.plugins.detekt) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
@@ -66,5 +67,28 @@ subprojects {
             // use the first script-level construct as the marker instead.
             licenseHeaderFile(licenseHeader, "(plugins|import|@file)")
         }
+    }
+}
+
+// Detekt — static analysis for code-smell-level issues (cyclomatic complexity,
+// long methods, magic numbers, exception swallowing, naming, etc.) — the things
+// ktlint deliberately doesn't touch. Existing violations live in
+// `config/detekt/baseline.xml`; new code is checked against the merged result
+// of defaults + `config/detekt.yml` overrides.
+val detektConfigFile = file("config/detekt.yml")
+val detektBaselineFile = file("config/detekt/baseline.xml")
+
+subprojects {
+    apply(plugin = "io.gitlab.arturbosch.detekt")
+
+    extensions.configure<io.gitlab.arturbosch.detekt.extensions.DetektExtension> {
+        config.setFrom(detektConfigFile)
+        baseline = detektBaselineFile
+        // Layer overrides on top of upstream defaults rather than replacing
+        // them; smaller config file, fewer surprises on Detekt bumps.
+        buildUponDefaultConfig = true
+        // Don't auto-correct on `detekt` — only via `detektFormat` (out of
+        // scope here; we already format via Spotless).
+        autoCorrect = false
     }
 }

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -1,0 +1,34 @@
+# Detekt config — only overrides upstream defaults where they need adjustment
+# for this project. `buildUponDefaultConfig = true` is set in the root build
+# script so any rule not listed here uses Detekt's stock setting.
+#
+# Generate `config/detekt/baseline.xml` to grandfather existing violations:
+#   ./gradlew detektBaseline
+#
+# Phase 4 (toolchain bump) and Phase 7 (real tests) will likely revisit these
+# thresholds — the goal here is "wired in, not noisy," not "maximally strict."
+
+build:
+  maxIssues: 0  # Any non-baselined violation fails the task.
+
+complexity:
+  LongParameterList:
+    # Room entities and DTO copy(...) calls naturally have many params.
+    functionThreshold: 8
+    constructorThreshold: 10
+  TooManyFunctions:
+    # Default 11 is tight for ViewModels / Fragments.
+    thresholdInClasses: 18
+    thresholdInObjects: 18
+
+style:
+  MagicNumber:
+    # Resource sizes, sleep durations, color hex literals — magic numbers in
+    # Android UI code are normal. Phase 4+ may revisit.
+    active: false
+  ReturnCount:
+    # Sealed-class branch handling often returns from each branch.
+    max: 4
+  WildcardImport:
+    # Already enforced by ktlint via Spotless; redundant here.
+    active: false

--- a/config/detekt/baseline.xml
+++ b/config/detekt/baseline.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<SmellBaseline>
+  <ManuallySuppressedIssues/>
+  <CurrentIssues>
+    <ID>MatchingDeclarationName:DataTransferObjects.kt$ImageOfTheDay</ID>
+    <ID>MatchingDeclarationName:DatabaseEntities.kt$DatabaseAsteroid</ID>
+    <ID>MaxLineLength:AsteroidDao.kt$AsteroidDao$@Query("SELECT * FROM asteroid_database WHERE closeApproachDate BETWEEN :startDate AND :endDate ORDER BY closeApproachDate ASC")</ID>
+    <ID>MaxLineLength:DetailFragment.kt$DetailFragment$okButton.setBackgroundColor(ContextCompat.getColor(requireContext(), R.color.buttonBackground))</ID>
+    <ID>MaxLineLength:DetailFragment.kt$DetailFragment$okButton.setTextColor(ContextCompat.getColor(requireContext(), R.color.highContrastText))</ID>
+    <ID>SpreadOperator:AsteroidRepository.kt$AsteroidRepository$( *parseAsteroidsJsonResult(JSONObject(asteroidsJson)) .asDatabaseModel(), )</ID>
+    <ID>SwallowedException:RefreshDataWorker.kt$RefreshDataWorker$e: HttpException</ID>
+    <ID>TooGenericExceptionCaught:AsteroidRepository.kt$AsteroidRepository$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:MainViewModel.kt$MainViewModel$e: Exception</ID>
+  </CurrentIssues>
+</SmellBaseline>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ junit = "4.13.2"
 # Code-quality tooling. Spotless 6.x is the last branch that runs cleanly on
 # Gradle 8.4 + Kotlin 1.6.x; Phase 4's toolchain bump can move to 7.x. ktlint
 # is pinned for reproducibility across machines.
+detekt = "1.23.8"
 ktlint = "1.5.0"
 spotless = "6.25.0"
 
@@ -122,5 +123,6 @@ androidx-navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", ver
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
## Summary

Phase 3b of [`docs/IMPROVEMENT_PLAN.md`](https://github.com/Tarek-Bohdima/AsteroidRadar/blob/master/docs/IMPROVEMENT_PLAN.md#phase-3--code-quality-plumbing). Second of three small Phase 3 PRs (Spotless ✅ → Detekt → Lint baseline).

- **Detekt 1.23.8** applied via root `subprojects {}` block — same pattern as Spotless. Catches code-smell-level issues (cyclomatic complexity, long methods, swallowed exceptions, naming, magic numbers, etc.) — the things ktlint deliberately doesn't touch.
- **`config/detekt.yml`** with `buildUponDefaultConfig = true` — small file, only lists overrides. `LongParameterList` raised to 8/10 (Room entities and DTOs naturally have many fields), `TooManyFunctions` raised to 18 (ViewModels / Fragments), `MagicNumber` disabled (Android UI code is full of legitimate magic numbers), `WildcardImport` disabled (already enforced by ktlint via Spotless).
- **`config/detekt/baseline.xml`** grandfathers 9 existing violations so this PR doesn't snowball into a code-cleanup. New code is checked against the ruleset, not the baseline.

## Baselined issues (intentional, not bugs)

| ID | File | Why baselined |
|---|---|---|
| `MatchingDeclarationName` | `DataTransferObjects.kt`, `DatabaseEntities.kt` | Grouping-by-domain naming; intentional. Same reason `ktlint_standard_filename` is disabled in `.editorconfig`. |
| `MaxLineLength` (×3) | `AsteroidDao.kt`, `DetailFragment.kt` | Room `@Query` SQL strings; `ContextCompat.getColor(...)` chain. Wrapping these hurts more than it helps. |
| `SpreadOperator` | `AsteroidRepository.kt` | Vararg expansion into `dao.insertAll(*items)` — that's the intended call. |
| `SwallowedException` | `RefreshDataWorker.kt` | `HttpException` is intentionally caught and turned into `Result.retry()`. |
| `TooGenericExceptionCaught` (×2) | `AsteroidRepository.kt`, `MainViewModel.kt` | Network paths catching `Exception` to log + degrade gracefully. Worth tightening eventually but a Phase 7 (tests) concern, not this one. |

CI gains a `detekt` step between `spotlessCheck` and `assembleDebug`. Same fast-fail ordering.

## Test plan

- [x] `./gradlew detekt` passes locally with baseline.
- [x] `./gradlew spotlessCheck detekt assembleDebug test` end-to-end clean.
- [x] CI on this PR runs the full chain — must stay green.

## Reviewer notes

- **No `detekt-formatting` ruleset.** It wraps ktlint, which Spotless already runs. Avoiding the duplicated work + duplicated diagnostics.
- **Detekt 1.23.8 vs 1.23.x latest** — 1.23.8 is current; later 1.23.x patches will arrive via Dependabot's `gradle-and-plugins` group. Detekt 2.x is in development and will be a Phase 4 follow-up after the Kotlin bump.
- **Baseline file location** at `config/detekt/baseline.xml` (not `app/detekt-baseline.xml`) so the convention plugin / future modules all share the same path. Detekt's regenerate command is `./gradlew detektBaseline`.

Fixes #57