### PR TITLE
build: bump Kotlin 1.6.21 to 2.0.21 (with KSP + unified coroutines)

### DIFF
--- a/build-logic/convention/src/main/kotlin/asteroidradar.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/asteroidradar.android.application.gradle.kts
@@ -30,6 +30,10 @@ import com.android.build.api.dsl.ApplicationExtension
 //
 // Plugin order matters: kotlin-android must precede
 // androidx.navigation.safeargs.kotlin (safe-args fails fast otherwise).
+//
+// `kotlin-kapt` is applied even though Room runs on KSP — AGP 8.3.0's
+// DataBinding compiler discovers @BindingAdapter methods via kapt. AGP 8.6+
+// moves DataBinding to KSP; drop kapt with the AGP bump.
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,8 +4,9 @@
 
 [versions]
 agp = "8.3.0"
-kotlin = "1.6.21"
-ksp = "1.9.0-1.0.13"
+kotlin = "2.0.21"
+# KSP versions track the Kotlin compiler they were built against — must match.
+ksp = "2.0.21-1.0.27"
 androidxNavigation = "2.7.7"
 
 androidxAppcompat = "1.6.1"
@@ -17,10 +18,9 @@ androidxRecyclerview = "1.3.2"
 androidxRoom = "2.6.1"
 androidxWork = "2.9.0"
 
-# Coroutines core and android live on different versions (1.6.4 vs 1.7.3) at
-# the pre-migration baseline. Phase 4 unifies them; until then keep both refs.
-kotlinxCoroutinesAndroid = "1.7.3"
-kotlinxCoroutinesCore = "1.6.4"
+# Coroutines core + android unified on a single ref now that they're part of
+# the same toolchain bump. Phase 4a goal.
+kotlinxCoroutines = "1.8.1"
 
 moshi = "1.15.1"
 picasso = "2.8"
@@ -59,8 +59,8 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidxWork" }
 
-kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutinesCore" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
@@ -121,6 +121,9 @@ android-test = [
 android-application = { id = "com.android.application", version.ref = "agp" }
 androidx-navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidxNavigation" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+# kapt is still applied because AGP 8.3.0's DataBinding compiler discovers
+# @BindingAdapter methods via kapt; AGP 8.6+ moves DataBinding to KSP. Drop
+# this entry once the AGP bump lands (a future PR after Phase 4).
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }


### PR DESCRIPTION
## Summary

Phase 4a of [`docs/IMPROVEMENT_PLAN.md`](https://github.com/Tarek-Bohdima/AsteroidRadar/blob/master/docs/IMPROVEMENT_PLAN.md#phase-4--toolchain-modernization). First of three small Phase 4 PRs (Kotlin → AndroidX → Picasso/Coil).

- **Kotlin 1.6.21 → 2.0.21.** Last 2.0.x — unblocks Phase 4b AndroidX bumps that require Kotlin 1.9+, while staying clear of K2-as-default surface area on Kotlin 2.1+. Easy to revisit later.
- **KSP 1.9.0-1.0.13 → 2.0.21-1.0.27.** KSP versions track the Kotlin compiler they were built against — this pair must match.
- **Coroutines unified** from split refs (1.6.4 core / 1.7.3 android) to one `kotlinxCoroutines = "1.8.1"` ref. Both `[libraries]` entries now share the same `version.ref`.

## Why kapt is staying applied

Was going to drop `kotlin-kapt` here (Room runs on KSP, no other annotation processor uses kapt). First attempt removed it, then `assembleDebug` failed with:

```
Cannot find a setter for <ImageView app:imageUrl> that accepts parameter type 'java.lang.String'
Cannot find a setter for <ImageView app:statusIcon> that accepts parameter type 'boolean'
Cannot find a setter for <ImageView app:asteroidStatusImage> that accepts parameter type 'boolean'
```

AGP 8.3.0's DataBinding compiler discovers `@BindingAdapter` methods via kapt. AGP 8.6+ moves DataBinding to KSP; until that AGP bump lands (a future PR — out of Phase 4 scope), kapt stays applied. Catalog entry + convention plugin both document the reason inline so the next reader doesn't repeat the attempt.

## Test plan

- [x] `./gradlew help` resolves (validates plugin / catalog wiring on Kotlin 2.0.21).
- [x] `./gradlew assembleDebug` builds the APK clean — DataBinding `@BindingAdapter` discovery still works (kapt path).
- [x] `./gradlew spotlessCheck detekt lintRelease test` — full quality gate green; no new violations against the existing baselines.
- [x] CI on this PR runs the same chain — must stay green.

## Reviewer notes

- **Why 2.0.21 and not 2.1.x or 2.2.x.** Kotlin 2.0 is the LTS-shaped floor (last release where K1 is the default compiler). Kotlin 2.1+ defaults to K2, which is great for new code but a heavier regression-test surface for an existing released app. We can ratchet to 2.1+ in a follow-up once 4b/4c land; this PR keeps the variable count down.
- **Coroutines 1.8.1.** Last 1.8.x; 1.9.x exists but the API surface is identical for our usage (one `withContext(Dispatchers.IO)` + `viewModelScope.launch` site each).
- **No source code changes.** The Kotlin bump compiled the existing source as-is — `data object` and other K1.9+ syntax we already use (e.g. in `AsteroidRepository.AsteroidsFilter`) work cleanly on 2.0.

## Tag

Next release is `v2.0.0-INTERNAL` once 4a/4b/4c are merged — the Kotlin major bump alone is breaking for any fork from the v1.x line.

Fixes #61