### PR TITLE
build: bump AndroidX libraries to current stable

### DIFF
--- a/app/lint-baseline.xml
+++ b/app/lint-baseline.xml
@@ -87,629 +87,596 @@
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.devtools.ksp than 1.9.0-1.0.13 is available: 2.3.7"
-        errorLine1="ksp = &quot;1.9.0-1.0.13&quot;"
-        errorLine2="      ~~~~~~~~~~~~~~">
+        message="A newer version of com.google.devtools.ksp than 2.0.21-1.0.27 is available: 2.3.7"
+        errorLine1="ksp = &quot;2.0.21-1.0.27&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="8"
+            line="9"
             column="7"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.devtools.ksp than 1.9.0-1.0.13 is available: 2.3.7"
-        errorLine1="ksp = &quot;1.9.0-1.0.13&quot;"
-        errorLine2="      ~~~~~~~~~~~~~~">
+        message="A newer version of com.google.devtools.ksp than 2.0.21-1.0.27 is available: 2.3.7"
+        errorLine1="ksp = &quot;2.0.21-1.0.27&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="8"
+            line="9"
             column="7"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.devtools.ksp than 1.9.0-1.0.13 is available: 2.3.7"
-        errorLine1="ksp = &quot;1.9.0-1.0.13&quot;"
-        errorLine2="      ~~~~~~~~~~~~~~">
+        message="A newer version of com.google.devtools.ksp than 2.0.21-1.0.27 is available: 2.3.7"
+        errorLine1="ksp = &quot;2.0.21-1.0.27&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="8"
+            line="9"
             column="7"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.devtools.ksp than 1.9.0-1.0.13 is available: 2.3.7"
-        errorLine1="ksp = &quot;1.9.0-1.0.13&quot;"
-        errorLine2="      ~~~~~~~~~~~~~~">
+        message="A newer version of com.google.devtools.ksp than 2.0.21-1.0.27 is available: 2.3.7"
+        errorLine1="ksp = &quot;2.0.21-1.0.27&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="8"
+            line="9"
             column="7"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.devtools.ksp than 1.9.0-1.0.13 is available: 2.3.7"
-        errorLine1="ksp = &quot;1.9.0-1.0.13&quot;"
-        errorLine2="      ~~~~~~~~~~~~~~">
+        message="A newer version of com.google.devtools.ksp than 2.0.21-1.0.27 is available: 2.3.7"
+        errorLine1="ksp = &quot;2.0.21-1.0.27&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="8"
+            line="9"
             column="7"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of com.google.devtools.ksp than 1.9.0-1.0.13 is available: 2.3.7"
-        errorLine1="ksp = &quot;1.9.0-1.0.13&quot;"
-        errorLine2="      ~~~~~~~~~~~~~~">
+        message="A newer version of com.google.devtools.ksp than 2.0.21-1.0.27 is available: 2.3.7"
+        errorLine1="ksp = &quot;2.0.21-1.0.27&quot;"
+        errorLine2="      ~~~~~~~~~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="8"
+            line="9"
             column="7"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation.safeargs.kotlin than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation.safeargs.kotlin than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation.safeargs.kotlin than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation.safeargs.kotlin than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation.safeargs.kotlin than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation.safeargs.kotlin than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation:navigation-fragment-ktx than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation:navigation-fragment-ktx than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation:navigation-fragment-ktx than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation:navigation-fragment-ktx than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation:navigation-fragment-ktx than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation:navigation-fragment-ktx than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation:navigation-safe-args-gradle-plugin than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation:navigation-safe-args-gradle-plugin than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation:navigation-safe-args-gradle-plugin than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation:navigation-safe-args-gradle-plugin than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation:navigation-safe-args-gradle-plugin than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation:navigation-safe-args-gradle-plugin than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation:navigation-ui-ktx than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation:navigation-ui-ktx than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation:navigation-ui-ktx than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation:navigation-ui-ktx than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.navigation:navigation-ui-ktx than 2.7.7 is available: 2.9.8"
-        errorLine1="androidxNavigation = &quot;2.7.7&quot;"
+        message="A newer version of androidx.navigation:navigation-ui-ktx than 2.8.5 is available: 2.9.8"
+        errorLine1="androidxNavigation = &quot;2.8.5&quot;"
         errorLine2="                     ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="9"
+            line="10"
             column="22"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.appcompat:appcompat than 1.6.1 is available: 1.7.1"
-        errorLine1="androidxAppcompat = &quot;1.6.1&quot;"
+        message="A newer version of androidx.appcompat:appcompat than 1.7.0 is available: 1.7.1"
+        errorLine1="androidxAppcompat = &quot;1.7.0&quot;"
         errorLine2="                    ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="11"
+            line="12"
             column="21"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.appcompat:appcompat than 1.6.1 is available: 1.7.1"
-        errorLine1="androidxAppcompat = &quot;1.6.1&quot;"
+        message="A newer version of androidx.appcompat:appcompat than 1.7.0 is available: 1.7.1"
+        errorLine1="androidxAppcompat = &quot;1.7.0&quot;"
         errorLine2="                    ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="11"
+            line="12"
             column="21"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.appcompat:appcompat than 1.6.1 is available: 1.7.1"
-        errorLine1="androidxAppcompat = &quot;1.6.1&quot;"
+        message="A newer version of androidx.appcompat:appcompat than 1.7.0 is available: 1.7.1"
+        errorLine1="androidxAppcompat = &quot;1.7.0&quot;"
         errorLine2="                    ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="11"
+            line="12"
             column="21"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.constraintlayout:constraintlayout than 2.1.4 is available: 2.2.1"
-        errorLine1="androidxConstraintlayout = &quot;2.1.4&quot;"
+        message="A newer version of androidx.constraintlayout:constraintlayout than 2.2.0 is available: 2.2.1"
+        errorLine1="androidxConstraintlayout = &quot;2.2.0&quot;"
         errorLine2="                           ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="12"
+            line="13"
             column="28"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.constraintlayout:constraintlayout than 2.1.4 is available: 2.2.1"
-        errorLine1="androidxConstraintlayout = &quot;2.1.4&quot;"
+        message="A newer version of androidx.constraintlayout:constraintlayout than 2.2.0 is available: 2.2.1"
+        errorLine1="androidxConstraintlayout = &quot;2.2.0&quot;"
         errorLine2="                           ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="12"
+            line="13"
             column="28"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.constraintlayout:constraintlayout than 2.1.4 is available: 2.2.1"
-        errorLine1="androidxConstraintlayout = &quot;2.1.4&quot;"
+        message="A newer version of androidx.constraintlayout:constraintlayout than 2.2.0 is available: 2.2.1"
+        errorLine1="androidxConstraintlayout = &quot;2.2.0&quot;"
         errorLine2="                           ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="12"
+            line="13"
             column="28"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.core:core-ktx than 1.12.0 is available: 1.18.0"
-        errorLine1="androidxCore = &quot;1.12.0&quot;"
+        message="A newer version of androidx.core:core-ktx than 1.15.0 is available: 1.18.0"
+        errorLine1="androidxCore = &quot;1.15.0&quot;"
         errorLine2="               ~~~~~~~~">
-        <location
-            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="13"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.core:core-ktx than 1.12.0 is available: 1.18.0"
-        errorLine1="androidxCore = &quot;1.12.0&quot;"
-        errorLine2="               ~~~~~~~~">
-        <location
-            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="13"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.core:core-ktx than 1.12.0 is available: 1.18.0"
-        errorLine1="androidxCore = &quot;1.12.0&quot;"
-        errorLine2="               ~~~~~~~~">
-        <location
-            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="13"
-            column="16"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.fragment:fragment-ktx than 1.6.2 is available: 1.8.9"
-        errorLine1="androidxFragment = &quot;1.6.2&quot;"
-        errorLine2="                   ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
             line="14"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.core:core-ktx than 1.15.0 is available: 1.18.0"
+        errorLine1="androidxCore = &quot;1.15.0&quot;"
+        errorLine2="               ~~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
+            line="14"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.core:core-ktx than 1.15.0 is available: 1.18.0"
+        errorLine1="androidxCore = &quot;1.15.0&quot;"
+        errorLine2="               ~~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
+            line="14"
+            column="16"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.fragment:fragment-ktx than 1.8.5 is available: 1.8.9"
+        errorLine1="androidxFragment = &quot;1.8.5&quot;"
+        errorLine2="                   ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
+            line="15"
             column="20"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.fragment:fragment-ktx than 1.6.2 is available: 1.8.9"
-        errorLine1="androidxFragment = &quot;1.6.2&quot;"
+        message="A newer version of androidx.fragment:fragment-ktx than 1.8.5 is available: 1.8.9"
+        errorLine1="androidxFragment = &quot;1.8.5&quot;"
         errorLine2="                   ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="14"
+            line="15"
             column="20"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.fragment:fragment-ktx than 1.6.2 is available: 1.8.9"
-        errorLine1="androidxFragment = &quot;1.6.2&quot;"
+        message="A newer version of androidx.fragment:fragment-ktx than 1.8.5 is available: 1.8.9"
+        errorLine1="androidxFragment = &quot;1.8.5&quot;"
         errorLine2="                   ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="14"
+            line="15"
             column="20"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.lifecycle:lifecycle-livedata-ktx than 2.7.0 is available: 2.10.0"
-        errorLine1="androidxLifecycle = &quot;2.7.0&quot;"
+        message="A newer version of androidx.lifecycle:lifecycle-livedata-ktx than 2.8.7 is available: 2.10.0"
+        errorLine1="androidxLifecycle = &quot;2.8.7&quot;"
         errorLine2="                    ~~~~~~~">
-        <location
-            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="15"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.lifecycle:lifecycle-livedata-ktx than 2.7.0 is available: 2.10.0"
-        errorLine1="androidxLifecycle = &quot;2.7.0&quot;"
-        errorLine2="                    ~~~~~~~">
-        <location
-            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="15"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.lifecycle:lifecycle-livedata-ktx than 2.7.0 is available: 2.10.0"
-        errorLine1="androidxLifecycle = &quot;2.7.0&quot;"
-        errorLine2="                    ~~~~~~~">
-        <location
-            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="15"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-ktx than 2.7.0 is available: 2.10.0"
-        errorLine1="androidxLifecycle = &quot;2.7.0&quot;"
-        errorLine2="                    ~~~~~~~">
-        <location
-            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="15"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-ktx than 2.7.0 is available: 2.10.0"
-        errorLine1="androidxLifecycle = &quot;2.7.0&quot;"
-        errorLine2="                    ~~~~~~~">
-        <location
-            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="15"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-ktx than 2.7.0 is available: 2.10.0"
-        errorLine1="androidxLifecycle = &quot;2.7.0&quot;"
-        errorLine2="                    ~~~~~~~">
-        <location
-            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="15"
-            column="21"/>
-    </issue>
-
-    <issue
-        id="GradleDependency"
-        message="A newer version of androidx.recyclerview:recyclerview than 1.3.2 is available: 1.4.0"
-        errorLine1="androidxRecyclerview = &quot;1.3.2&quot;"
-        errorLine2="                       ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
             line="16"
-            column="24"/>
+            column="21"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.recyclerview:recyclerview than 1.3.2 is available: 1.4.0"
-        errorLine1="androidxRecyclerview = &quot;1.3.2&quot;"
-        errorLine2="                       ~~~~~~~">
+        message="A newer version of androidx.lifecycle:lifecycle-livedata-ktx than 2.8.7 is available: 2.10.0"
+        errorLine1="androidxLifecycle = &quot;2.8.7&quot;"
+        errorLine2="                    ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
             line="16"
-            column="24"/>
+            column="21"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.recyclerview:recyclerview than 1.3.2 is available: 1.4.0"
-        errorLine1="androidxRecyclerview = &quot;1.3.2&quot;"
-        errorLine2="                       ~~~~~~~">
+        message="A newer version of androidx.lifecycle:lifecycle-livedata-ktx than 2.8.7 is available: 2.10.0"
+        errorLine1="androidxLifecycle = &quot;2.8.7&quot;"
+        errorLine2="                    ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
             line="16"
-            column="24"/>
+            column="21"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.room:room-compiler than 2.6.1 is available: 2.8.4"
-        errorLine1="androidxRoom = &quot;2.6.1&quot;"
+        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-ktx than 2.8.7 is available: 2.10.0"
+        errorLine1="androidxLifecycle = &quot;2.8.7&quot;"
+        errorLine2="                    ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
+            line="16"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-ktx than 2.8.7 is available: 2.10.0"
+        errorLine1="androidxLifecycle = &quot;2.8.7&quot;"
+        errorLine2="                    ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
+            line="16"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.lifecycle:lifecycle-viewmodel-ktx than 2.8.7 is available: 2.10.0"
+        errorLine1="androidxLifecycle = &quot;2.8.7&quot;"
+        errorLine2="                    ~~~~~~~">
+        <location
+            file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
+            line="16"
+            column="21"/>
+    </issue>
+
+    <issue
+        id="GradleDependency"
+        message="A newer version of androidx.room:room-compiler than 2.7.2 is available: 2.8.4"
+        errorLine1="androidxRoom = &quot;2.7.2&quot;"
         errorLine2="               ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="17"
+            line="19"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.room:room-compiler than 2.6.1 is available: 2.8.4"
-        errorLine1="androidxRoom = &quot;2.6.1&quot;"
+        message="A newer version of androidx.room:room-compiler than 2.7.2 is available: 2.8.4"
+        errorLine1="androidxRoom = &quot;2.7.2&quot;"
         errorLine2="               ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="17"
+            line="19"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.room:room-compiler than 2.6.1 is available: 2.8.4"
-        errorLine1="androidxRoom = &quot;2.6.1&quot;"
+        message="A newer version of androidx.room:room-compiler than 2.7.2 is available: 2.8.4"
+        errorLine1="androidxRoom = &quot;2.7.2&quot;"
         errorLine2="               ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="17"
+            line="19"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.room:room-ktx than 2.6.1 is available: 2.8.4"
-        errorLine1="androidxRoom = &quot;2.6.1&quot;"
+        message="A newer version of androidx.room:room-ktx than 2.7.2 is available: 2.8.4"
+        errorLine1="androidxRoom = &quot;2.7.2&quot;"
         errorLine2="               ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="17"
+            line="19"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.room:room-ktx than 2.6.1 is available: 2.8.4"
-        errorLine1="androidxRoom = &quot;2.6.1&quot;"
+        message="A newer version of androidx.room:room-ktx than 2.7.2 is available: 2.8.4"
+        errorLine1="androidxRoom = &quot;2.7.2&quot;"
         errorLine2="               ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="17"
+            line="19"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.room:room-ktx than 2.6.1 is available: 2.8.4"
-        errorLine1="androidxRoom = &quot;2.6.1&quot;"
+        message="A newer version of androidx.room:room-ktx than 2.7.2 is available: 2.8.4"
+        errorLine1="androidxRoom = &quot;2.7.2&quot;"
         errorLine2="               ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="17"
+            line="19"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.room:room-runtime than 2.6.1 is available: 2.8.4"
-        errorLine1="androidxRoom = &quot;2.6.1&quot;"
+        message="A newer version of androidx.room:room-runtime than 2.7.2 is available: 2.8.4"
+        errorLine1="androidxRoom = &quot;2.7.2&quot;"
         errorLine2="               ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="17"
+            line="19"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.room:room-runtime than 2.6.1 is available: 2.8.4"
-        errorLine1="androidxRoom = &quot;2.6.1&quot;"
+        message="A newer version of androidx.room:room-runtime than 2.7.2 is available: 2.8.4"
+        errorLine1="androidxRoom = &quot;2.7.2&quot;"
         errorLine2="               ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="17"
+            line="19"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.room:room-runtime than 2.6.1 is available: 2.8.4"
-        errorLine1="androidxRoom = &quot;2.6.1&quot;"
+        message="A newer version of androidx.room:room-runtime than 2.7.2 is available: 2.8.4"
+        errorLine1="androidxRoom = &quot;2.7.2&quot;"
         errorLine2="               ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="17"
+            line="19"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.work:work-runtime-ktx than 2.9.0 is available: 2.11.2"
-        errorLine1="androidxWork = &quot;2.9.0&quot;"
-        errorLine2="               ~~~~~~~">
+        message="A newer version of androidx.work:work-runtime-ktx than 2.10.0 is available: 2.11.2"
+        errorLine1="androidxWork = &quot;2.10.0&quot;"
+        errorLine2="               ~~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="18"
+            line="20"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.work:work-runtime-ktx than 2.9.0 is available: 2.11.2"
-        errorLine1="androidxWork = &quot;2.9.0&quot;"
-        errorLine2="               ~~~~~~~">
+        message="A newer version of androidx.work:work-runtime-ktx than 2.10.0 is available: 2.11.2"
+        errorLine1="androidxWork = &quot;2.10.0&quot;"
+        errorLine2="               ~~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="18"
+            line="20"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of androidx.work:work-runtime-ktx than 2.9.0 is available: 2.11.2"
-        errorLine1="androidxWork = &quot;2.9.0&quot;"
-        errorLine2="               ~~~~~~~">
+        message="A newer version of androidx.work:work-runtime-ktx than 2.10.0 is available: 2.11.2"
+        errorLine1="androidxWork = &quot;2.10.0&quot;"
+        errorLine2="               ~~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="18"
+            line="20"
             column="16"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-android than 1.7.3 is available: 1.10.2"
-        errorLine1="kotlinxCoroutinesAndroid = &quot;1.7.3&quot;"
-        errorLine2="                           ~~~~~~~">
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-android than 1.8.1 is available: 1.10.2"
+        errorLine1="kotlinxCoroutines = &quot;1.8.1&quot;"
+        errorLine2="                    ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="22"
-            column="28"/>
+            line="24"
+            column="21"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-android than 1.7.3 is available: 1.10.2"
-        errorLine1="kotlinxCoroutinesAndroid = &quot;1.7.3&quot;"
-        errorLine2="                           ~~~~~~~">
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-android than 1.8.1 is available: 1.10.2"
+        errorLine1="kotlinxCoroutines = &quot;1.8.1&quot;"
+        errorLine2="                    ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="22"
-            column="28"/>
+            line="24"
+            column="21"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-android than 1.7.3 is available: 1.10.2"
-        errorLine1="kotlinxCoroutinesAndroid = &quot;1.7.3&quot;"
-        errorLine2="                           ~~~~~~~">
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-android than 1.8.1 is available: 1.10.2"
+        errorLine1="kotlinxCoroutines = &quot;1.8.1&quot;"
+        errorLine2="                    ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="22"
-            column="28"/>
+            line="24"
+            column="21"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-core than 1.6.4 is available: 1.9.0"
-        errorLine1="kotlinxCoroutinesCore = &quot;1.6.4&quot;"
-        errorLine2="                        ~~~~~~~">
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-core than 1.8.1 is available: 1.9.0"
+        errorLine1="kotlinxCoroutines = &quot;1.8.1&quot;"
+        errorLine2="                    ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="23"
-            column="25"/>
+            line="24"
+            column="21"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-core than 1.6.4 is available: 1.9.0"
-        errorLine1="kotlinxCoroutinesCore = &quot;1.6.4&quot;"
-        errorLine2="                        ~~~~~~~">
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-core than 1.8.1 is available: 1.9.0"
+        errorLine1="kotlinxCoroutines = &quot;1.8.1&quot;"
+        errorLine2="                    ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="23"
-            column="25"/>
+            line="24"
+            column="21"/>
     </issue>
 
     <issue
         id="GradleDependency"
-        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-core than 1.6.4 is available: 1.9.0"
-        errorLine1="kotlinxCoroutinesCore = &quot;1.6.4&quot;"
-        errorLine2="                        ~~~~~~~">
+        message="A newer version of org.jetbrains.kotlinx:kotlinx-coroutines-core than 1.8.1 is available: 1.9.0"
+        errorLine1="kotlinxCoroutines = &quot;1.8.1&quot;"
+        errorLine2="                    ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="23"
-            column="25"/>
+            line="24"
+            column="21"/>
     </issue>
 
     <issue
@@ -719,7 +686,7 @@
         errorLine2="           ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="27"
+            line="28"
             column="12"/>
     </issue>
 
@@ -730,7 +697,7 @@
         errorLine2="           ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="27"
+            line="28"
             column="12"/>
     </issue>
 
@@ -741,7 +708,7 @@
         errorLine2="           ~~~~~~~">
         <location
             file="$HOME/StudioProjects/AsteroidRadar/gradle/libs.versions.toml"
-            line="27"
+            line="28"
             column="12"/>
     </issue>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,16 +7,17 @@ agp = "8.3.0"
 kotlin = "2.0.21"
 # KSP versions track the Kotlin compiler they were built against — must match.
 ksp = "2.0.21-1.0.27"
-androidxNavigation = "2.7.7"
+androidxNavigation = "2.8.5"
 
-androidxAppcompat = "1.6.1"
-androidxConstraintlayout = "2.1.4"
-androidxCore = "1.12.0"
-androidxFragment = "1.6.2"
-androidxLifecycle = "2.7.0"
-androidxRecyclerview = "1.3.2"
-androidxRoom = "2.6.1"
-androidxWork = "2.9.0"
+androidxAppcompat = "1.7.0"
+androidxConstraintlayout = "2.2.0"
+androidxCore = "1.15.0"
+androidxFragment = "1.8.5"
+androidxLifecycle = "2.8.7"
+androidxRecyclerview = "1.4.0"
+# Room 2.8.x requires AGP >= 8.5; staying on 2.7.x until the AGP bump PR.
+androidxRoom = "2.7.2"
+androidxWork = "2.10.0"
 
 # Coroutines core + android unified on a single ref now that they're part of
 # the same toolchain bump. Phase 4a goal.


### PR DESCRIPTION
## Summary

Phase 4b of [`docs/IMPROVEMENT_PLAN.md`](https://github.com/Tarek-Bohdima/AsteroidRadar/blob/master/docs/IMPROVEMENT_PLAN.md#phase-4--toolchain-modernization). Second of three small Phase 4 PRs (Kotlin ✅ → AndroidX → Picasso/Coil).

Every AndroidX dep moves to current stable (AGP 8.3.0-compatible). The pre-bump baseline was 1-4 years old per library.

| Library | Before | After |
|---|---|---|
| `androidx.appcompat` | 1.6.1 | 1.7.0 |
| `androidx.constraintlayout` | 2.1.4 | 2.2.0 |
| `androidx.core:core-ktx` | 1.12.0 | 1.15.0 |
| `androidx.fragment` | 1.6.2 | 1.8.5 |
| `androidx.lifecycle` | 2.7.0 | 2.8.7 |
| `androidx.navigation` | 2.7.7 | 2.8.5 |
| `androidx.recyclerview` | 1.3.2 | 1.4.0 |
| `androidx.room` | 2.6.1 | 2.7.2 |
| `androidx.work` | 2.9.0 | 2.10.0 |

Room 2.8.x requires AGP ≥ 8.5; staying on 2.7.x until the dedicated AGP-bump PR. Same logic applies to any other lib that surfaces an AGP-version floor — they'll bump when AGP does.

## Test plan

- [x] `./gradlew assembleDebug` clean.
- [x] `./gradlew spotlessCheck detekt lintRelease test` — full quality gate green; no new violations against existing baselines.
- [x] CI on this PR runs the same chain — must stay green.
- [x] `app/lint-baseline.xml` regenerated post-bump.

## What didn't change

- **Source code.** Every API we use is binary-compat across these jumps. No method renames, no deprecated-removed classes hit. Navigation 2.8 / lifecycle 2.8 / fragment 1.8 / room 2.7 keep their old APIs working.
- **Detekt baseline.** No new code-smell signal from the bumped libs.
- **AGP / Gradle wrapper.** AGP 8.3.0 stays. Gradle 8.4 stays. Those move in a separate dedicated PR.

## Build output to know about (neither blocks)

- `kapt currently doesn't support language version 2.0+. Falling back to 1.9.` — expected. kapt is in soft-deprecation; it falls back to the K1 compiler for processing. Goes away when AGP 8.6+ lands and we move DataBinding to KSP.
- Six `error: string too large to encode using UTF-8 written instead as 'STRING_TOO_LARGE'.` lines during `processDebugResources`. Pre-existing AAPT2 chatter on long string resources (likely vector pathData attributes — Lint already flags 7 `VectorPath` warnings in the baseline). Printed as "error" but treated as warning; build succeeds. Out of scope for this PR.

## Lint baseline shrink (modest)

Before this PR: 60 `GradleDependency` warnings. After: **57.** The other ~50 are transitive deps Lint can see through to (e.g. `androidx.lifecycle:lifecycle-common` even though we only depend on `lifecycle-livedata-ktx`). Phase 4c won't touch these; the AGP bump PR will resolve more of them.

Fixes #63