### PR TITLE
docs: relax tag-per-phase policy to ship-when-ready

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,13 +67,14 @@ The classifier suffix maps cleanly to Play tracks:
 
 **Conventions:**
 
-- Tag at phase boundaries from `docs/IMPROVEMENT_PLAN.md`, not arbitrarily.
-- Every tag is a GitHub Release with auto-generated notes (the existing release workflow handles this).
+- Bump `versionMajor/Minor/Patch` in `app/build.gradle.kts` as part of the PR that earns the bump, so the version-of-record on `master` always reflects what's there. Doc/CI/dep-bump-only PRs skip the bump.
+- Cut a tag only when actually shipping a build — phases can stack into a single tag. e.g. Phases 4 + 5 + 6 ship as one `v2.0.0-INTERNAL` once the toolchain + DI + R8 rewrite is on a device, not three separate cuts. The version field tracks the work; the tag tracks shipments.
+- When we tag, the release workflow runs: signed APK + AAB build, GitHub Release with auto-generated notes, AAB attached as a workflow artifact (Play Store upload stays manual).
 - Tag names containing `INTERNAL`, `alpha`, `beta`, `rc`, or `RC` auto-flag as pre-release.
 
 `.github/workflows/release.yml` runs on tags matching `v*`:
 
-1. **Validates** that `vMAJOR.MINOR.PATCH` (classifier ignored) matches `versionMajor/Minor/Patch` in `app/build.gradle`. Mismatch fails the workflow before building. Always update `build.gradle` and commit before tagging.
+1. **Validates** that `vMAJOR.MINOR.PATCH` (classifier ignored) matches `versionMajor/Minor/Patch` in `app/build.gradle.kts`. Mismatch fails the workflow before building. Always update `build.gradle.kts` and commit before tagging.
 2. Runs unit tests, decodes `KEYSTORE_BASE64` to a temp `.jks`, builds signed APK + AAB.
 3. Attaches the APK to the GitHub Release; uploads the AAB as a workflow artifact (Play Store uploads are manual).
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -27,10 +27,12 @@ the rough size; sub-bullets are the concrete deltas.
 ## Versioning and tags
 
 Tag/release policy lives in [`CLAUDE.md`](../CLAUDE.md#versioning-and-tags).
-Cut a tag at every phase boundary — don't accumulate three phases into one
-release. Phase 0 lands as a PATCH (`v1.3.6-INTERNAL`). The toolchain bump in
-Phase 4 is breaking for any fork (Kotlin major, dependency replacements) and
-ships as MAJOR (`v2.0.0-INTERNAL`).
+tl;dr: bump `versionMajor/Minor/Patch` in `app/build.gradle.kts` per phase
+that earns it, so the version-of-record stays honest, but only cut a tag
+(which triggers a release workflow run + Internal-track-eligible signed
+build) when there's an actual reason to ship. Phases can stack into a single
+tag. Phase 4's toolchain bump puts the project at `v2.0.0-INTERNAL` in the
+build script whether or not we tag immediately.
 
 ---
 


### PR DESCRIPTION
## Summary
- Replace "cut a tag at every phase boundary" with "bump the version field per phase, but only tag when actually shipping a build to Internal" — phases stack freely into one tag
- Rationale: solo project, Internal track only; the previous policy generated a signed-AAB + GitHub Release for every modernization PR even when nothing user-facing changed. The version-of-record still moves per phase (so `master` reflects what's there), but the workflow run is gated on intent to ship
- Fix a stale `app/build.gradle` reference in `CLAUDE.md` left over from Phase 1's Kotlin DSL migration

## Notes / follow-ups (not in this PR)
- `CLAUDE.md` line 129 still claims `kotlin-kapt` "isn't currently used by any processor" — actually it's used by AGP 8.3.0's DataBinding compiler (per `libs.versions.toml:135`). Worth fixing in the next docs sweep, or when AGP 8.6+ moves DataBinding to KSP and we can drop kapt entirely
- Existing tags (`v1.3.5`, etc.) carry no classifier even though `versionClassifier = "INTERNAL"` is set in the build script. Not changing here; will sort itself out the next time we actually tag

## Test plan
- [x] No code changes — docs only
- [x] Markdown renders cleanly in the GitHub preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)