### PR TITLE
ci: skip PR build for docs-only changes

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -19,7 +19,38 @@ concurrency:
 # tag can't silently swap behavior under us. Dependabot's `github-actions`
 # ecosystem auto-bumps these on a weekly cadence.
 jobs:
+  # Cheap (~10s) gate that decides whether the heavy `build` job runs. If a PR
+  # only touches docs (Markdown / docs/ / LICENSE / .gitignore), `build` is
+  # skipped — and a skipped required check counts as "passing" in branch
+  # protection, so docs PRs merge without burning gradle minutes. Update the
+  # regex below if a new docs-only path is added (e.g. screenshots/).
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Detect non-docs changes
+        id: filter
+        run: |
+          changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          echo "Changed files in this PR:"
+          echo "$changed"
+          if echo "$changed" | grep -qvE '\.md$|^docs/|^LICENSE$|^\.gitignore$'; then
+            echo "code=true"  >> "$GITHUB_OUTPUT"
+            echo "Decision: code changes present — running build."
+          else
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            echo "Decision: docs-only PR — skipping build."
+          fi
+
   build:
+    needs: detect
+    if: needs.detect.outputs.code == 'true'
     runs-on: ubuntu-latest
     env:
       NASA_API_KEY: ${{ secrets.NASA_API_KEY }}

--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -36,8 +36,23 @@ jobs:
 
       - name: Detect non-docs changes
         id: filter
+        # `BASE_REF` is passed through `env` rather than interpolated directly
+        # into the script. Templated `${{ … }}` is expanded by the Actions
+        # engine before bash sees it, so any context value that ever contained
+        # shell metacharacters would become arbitrary command execution. Going
+        # via `env` makes it a regular shell variable that bash treats as data.
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          changed=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          set -euo pipefail
+          # Fail closed: if the diff itself fails for any reason, run the full
+          # build rather than silently skipping it. `set -e` doesn't trip on a
+          # failure inside `$(…)`, so check the exit status explicitly.
+          if ! changed=$(git diff --name-only "origin/${BASE_REF}...HEAD"); then
+            echo "git diff failed — defaulting to a full build run." >&2
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           echo "Changed files in this PR:"
           echo "$changed"
           if echo "$changed" | grep -qvE '\.md$|^docs/|^LICENSE$|^\.gitignore$'; then


### PR DESCRIPTION
## Summary
- New `detect` job (~10s) diffs the PR against its base ref and emits `code=true|false` based on whether anything outside the docs allowlist (`*.md`, `docs/`, `LICENSE`, `.gitignore`) changed
- Existing `build` job gains `needs: detect` + `if: needs.detect.outputs.code == 'true'` — when skipped, the required `build` check still reports as "passing" so docs PRs merge cleanly
- Inline bash rather than a `dorny/paths-filter`-style action: keeps Dependabot surface small, keeps the allowlist regex visible at the call site

## Why this PR itself runs the full build
This PR modifies `.github/workflows/build_pull_request.yml` — a non-docs path — so `detect` will report `code=true` and `build` runs as normal. That's exactly the safe path: workflow changes always exercise the full pipeline.

## Verification plan
- [x] PR opens and the new `detect` job appears in checks
- [x] `build` runs against this PR (since the workflow file itself changed)
- [ ] Once merged, a follow-up docs-only PR will demonstrate the skip path

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)