### PR TITLE
build: add Hilt convention plugin + @HiltAndroidApp (Phase 5a)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,7 @@ import java.util.Properties
 // buildTypes, sourceSets, dataBinding).
 plugins {
     id("asteroidradar.android.application")
+    id("asteroidradar.android.hilt")
 }
 
 // Version components — bump these (not versionCode / versionName directly) when

--- a/app/src/main/java/com/tarek/asteroidradar/AsteroidRadarApplication.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/AsteroidRadarApplication.kt
@@ -35,12 +35,14 @@ import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import com.tarek.asteroidradar.work.RefreshDataWorker
+import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
 
+@HiltAndroidApp
 class AsteroidRadarApplication : Application() {
     private val applicationScope = CoroutineScope(Dispatchers.Default)
 

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -43,4 +43,5 @@ dependencies {
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.ksp.gradle.plugin)
     implementation(libs.androidx.navigation.safeargs.gradle.plugin)
+    implementation(libs.hilt.gradle.plugin)
 }

--- a/build-logic/convention/src/main/kotlin/asteroidradar.android.hilt.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/asteroidradar.android.hilt.gradle.kts
@@ -1,0 +1,56 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import dagger.hilt.android.plugin.HiltExtension
+import org.gradle.api.artifacts.VersionCatalogsExtension
+
+// Standalone Hilt convention. Applied alongside `asteroidradar.android.application`
+// in :app today; future feature/library modules can opt into DI by adding this
+// plugin alone (their `*.android.library` convention will bring KSP).
+//
+// `enableAggregatingTask = true` has been Hilt's default since 2.45 — kept
+// explicit so the intent travels with the plugin rather than relying on an
+// upstream default that could flip.
+//
+// KSP is re-declared here even though the application convention already
+// applies it; Gradle's plugin manager dedupes by id, and keeping it here makes
+// this convention work in a module that doesn't bring KSP itself.
+//
+// Catalog access uses `VersionCatalogsExtension` rather than the
+// `LibrariesForLibs` typed accessor — the latter isn't generated for the
+// build-logic compileKotlin classpath without an extra workaround, and the
+// public API stays portable across Gradle minors.
+plugins {
+    id("com.google.devtools.ksp")
+    id("com.google.dagger.hilt.android")
+}
+
+configure<HiltExtension> {
+    enableAggregatingTask = true
+}
+
+private val libs = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
+
+dependencies {
+    "implementation"(libs.findLibrary("hilt-android").get())
+    "ksp"(libs.findLibrary("hilt-compiler").get())
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,10 @@ androidxWork = "2.10.0"
 kotlinxCoroutines = "1.8.1"
 
 coil = "2.7.0"
+# Hilt 2.51+ supports Kotlin 2.x via KSP, which is why DI lands after Phase 4's
+# Kotlin bump. `enableAggregatingTask = true` (the default since 2.45) is kept
+# explicit in the convention plugin.
+hilt = "2.52"
 moshi = "1.15.2"
 retrofit = "3.0.0"
 retrofitCoroutinesAdapter = "0.9.2"
@@ -77,6 +81,8 @@ retrofit-converter-scalars = { module = "com.squareup.retrofit2:converter-scalar
 retrofit-coroutines-adapter = { module = "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter", version.ref = "retrofitCoroutinesAdapter" }
 
 coil = { module = "io.coil-kt:coil", version.ref = "coil" }
+hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
+hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidxEspresso" }
@@ -93,6 +99,7 @@ android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 androidx-navigation-safeargs-gradle-plugin = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "androidxNavigation" }
+hilt-gradle-plugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "hilt" }
 
 [bundles]
 # Lifecycle-related libs that travel together (Modexa trick #6). When adding a
@@ -138,5 +145,6 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
## Summary

- First of three Hilt sub-PRs. Stands up the build pipeline so 5b can land `@HiltViewModel` + the DB module without further Gradle churn.
- New `asteroidradar.android.hilt` convention plugin (applies `com.google.dagger.hilt.android` + `com.google.devtools.ksp`, pins `enableAggregatingTask = true`, declares `hilt-android` impl + `hilt-compiler` KSP).
- `AsteroidRadarApplication` gets `@HiltAndroidApp`, but no runtime wiring moves yet — `MainViewModel.Factory` and `getDatabase()` are still the only construction sites.

## Notes

- Catalog access in the new convention plugin uses `VersionCatalogsExtension` rather than `LibrariesForLibs` — the typed accessor isn't generated on the build-logic compileKotlin classpath without an extra workaround, and the public API stays portable across Gradle minors.
- Hilt's annotation-processor option strings leak into kapt (`dagger.hilt.internal.useAggregatingRootProcessor`, etc.) producing benign \"not recognized by any processor\" warnings. They disappear when DataBinding moves off kapt with the AGP 8.6+ bump tracked by #78.

## Test plan

- [x] `./gradlew spotlessCheck detekt` — green
- [x] `./gradlew lintRelease assembleDebug test` — green
- [ ] CI build job (`detect` + `build`) green on the PR
- [ ] Device smoke deferred to the Phase 4/5 combined cut (per the improvement plan, sub-PRs don't tag individually)

Refs #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)