### PR TITLE
feat: migrate MainViewModel to Hilt + introduce DatabaseModule (Phase 5b)

### DIFF
--- a/app/src/main/java/com/tarek/asteroidradar/di/DatabaseModule.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/di/DatabaseModule.kt
@@ -26,16 +26,38 @@
  * I, the author of the project, allow you to check the code as a reference, but
  * if you submit it, it's your own responsibility if you get expelled.
  */
-package com.tarek.asteroidradar
+package com.tarek.asteroidradar.di
 
-import android.os.Bundle
-import androidx.appcompat.app.AppCompatActivity
-import dagger.hilt.android.AndroidEntryPoint
+import android.content.Context
+import com.tarek.asteroidradar.database.AsteroidDao
+import com.tarek.asteroidradar.database.AsteroidDatabase
+import com.tarek.asteroidradar.database.getDatabase
+import com.tarek.asteroidradar.repository.AsteroidRepository
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
 
-@AndroidEntryPoint
-class MainActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
-    }
+// Hilt module for database + repository graph. Phase 5b only — `getDatabase()`
+// is intentionally kept as the construction site so :app (via Hilt) and
+// `RefreshDataWorker` (still pre-Hilt this phase) share a single Room instance.
+// Phase 5c migrates the worker, deletes `getDatabase()`, and inlines
+// `Room.databaseBuilder(...)` here.
+@Module
+@InstallIn(SingletonComponent::class)
+object DatabaseModule {
+    @Provides
+    @Singleton
+    fun provideAsteroidDatabase(
+        @ApplicationContext context: Context,
+    ): AsteroidDatabase = getDatabase(context)
+
+    @Provides
+    fun provideAsteroidDao(database: AsteroidDatabase): AsteroidDao = database.asteroidDao
+
+    @Provides
+    @Singleton
+    fun provideAsteroidRepository(database: AsteroidDatabase): AsteroidRepository = AsteroidRepository(database)
 }

--- a/app/src/main/java/com/tarek/asteroidradar/ui/detail/DetailFragment.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/ui/detail/DetailFragment.kt
@@ -37,7 +37,9 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import com.tarek.asteroidradar.R
 import com.tarek.asteroidradar.databinding.FragmentDetailBinding
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class DetailFragment : Fragment() {
     private lateinit var binding: FragmentDetailBinding
 

--- a/app/src/main/java/com/tarek/asteroidradar/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/ui/main/MainFragment.kt
@@ -44,16 +44,16 @@ import androidx.navigation.fragment.findNavController
 import com.tarek.asteroidradar.R
 import com.tarek.asteroidradar.databinding.FragmentMainBinding
 import com.tarek.asteroidradar.repository.AsteroidRepository
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 @Suppress("ktlint:standard:no-consecutive-comments")
 class MainFragment : Fragment() {
     @Suppress("ktlint:standard:backing-property-naming")
     private var _binding: FragmentMainBinding? = null
     private val binding get() = _binding!!
 
-    private val viewModel: MainViewModel by viewModels {
-        MainViewModel.Factory(requireActivity().application)
-    }
+    private val viewModel: MainViewModel by viewModels()
 
     override fun onCreateView(
         inflater: LayoutInflater,

--- a/app/src/main/java/com/tarek/asteroidradar/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/ui/main/MainViewModel.kt
@@ -28,97 +28,80 @@
  */
 package com.tarek.asteroidradar.ui.main
 
-import android.app.Application
-import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.switchMap
 import androidx.lifecycle.viewModelScope
-import com.tarek.asteroidradar.database.getDatabase
 import com.tarek.asteroidradar.domain.Asteroid
 import com.tarek.asteroidradar.domain.PictureOfDay
 import com.tarek.asteroidradar.repository.AsteroidRepository
 import com.tarek.asteroidradar.repository.AsteroidRepository.AsteroidsFilter
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import timber.log.Timber
+import javax.inject.Inject
 
-class MainViewModel(
-    application: Application,
-) : AndroidViewModel(application) {
-    private val database = getDatabase(application)
-    private val repository = AsteroidRepository(database)
+@HiltViewModel
+class MainViewModel
+    @Inject
+    constructor(
+        private val repository: AsteroidRepository,
+    ) : ViewModel() {
+        private val _imageOfTheDay = MutableLiveData<PictureOfDay>()
+        val imageOfTheDay: LiveData<PictureOfDay>
+            get() = _imageOfTheDay
 
-    private val _imageOfTheDay = MutableLiveData<PictureOfDay>()
-    val imageOfTheDay: LiveData<PictureOfDay>
-        get() = _imageOfTheDay
+        private val _navigateToDetail = MutableLiveData<Asteroid?>()
+        val navigateToDetail
+            get() = _navigateToDetail
 
-    private val _navigateToDetail = MutableLiveData<Asteroid?>()
-    val navigateToDetail
-        get() = _navigateToDetail
+        private val _filter = MutableLiveData<AsteroidsFilter>()
+        val filter
+            get() = _filter
 
-    private val _filter = MutableLiveData<AsteroidsFilter>()
-    val filter
-        get() = _filter
-
-    val asteroids =
-        filter.switchMap {
-            repository.getAsteroidSelection(it)
-        }
-
-    init {
-        viewModelScope.launch {
-            getAsteroidList()
-            getImageOfTheDay()
-        }
-    }
-
-    private suspend fun getImageOfTheDay() {
-        try {
-            _imageOfTheDay.value = repository.getImageOfTheDay()
-        } catch (e: Exception) {
-            Timber.d("MainViewModel: getImageOfTheDay called : %s", e.message)
-        }
-    }
-
-    private suspend fun getAsteroidList() {
-        try {
-            repository.refreshAsteroids()
-        } catch (e: Exception) {
-            Timber.d("MainViewModel: getAsteroidList() called : %s", e.message)
-        }
-    }
-
-    fun onAsteroidClicked(asteroid: Asteroid) {
-        _navigateToDetail.value = asteroid
-    }
-
-    fun onAsteroidDetailNavigated() {
-        _navigateToDetail.value = null
-    }
-
-    /**
-     * Updates the data set filter for the web services by querying the data with the new filter
-     * by calling [getAsteroidList]
-     * @param filter the [AsteroidsFilter] that is sent as part of the web server request
-     */
-    fun updateFilters(filter: AsteroidsFilter) {
-        _filter.value = filter
-    }
-
-    /**
-     * Factory for constructing MainViewModel with parameter
-     */
-    class Factory(
-        val app: Application,
-    ) : ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            if (modelClass.isAssignableFrom(MainViewModel::class.java)) {
-                @Suppress("UNCHECKED_CAST")
-                return MainViewModel(app) as T
+        val asteroids =
+            filter.switchMap {
+                repository.getAsteroidSelection(it)
             }
-            throw IllegalArgumentException("Unable to construct viewmodel")
+
+        init {
+            viewModelScope.launch {
+                getAsteroidList()
+                getImageOfTheDay()
+            }
+        }
+
+        private suspend fun getImageOfTheDay() {
+            try {
+                _imageOfTheDay.value = repository.getImageOfTheDay()
+            } catch (e: Exception) {
+                Timber.d("MainViewModel: getImageOfTheDay called : %s", e.message)
+            }
+        }
+
+        private suspend fun getAsteroidList() {
+            try {
+                repository.refreshAsteroids()
+            } catch (e: Exception) {
+                Timber.d("MainViewModel: getAsteroidList() called : %s", e.message)
+            }
+        }
+
+        fun onAsteroidClicked(asteroid: Asteroid) {
+            _navigateToDetail.value = asteroid
+        }
+
+        fun onAsteroidDetailNavigated() {
+            _navigateToDetail.value = null
+        }
+
+        /**
+         * Updates the data set filter for the web services by querying the data with the new filter
+         * by calling [getAsteroidList]
+         * @param filter the [AsteroidsFilter] that is sent as part of the web server request
+         */
+        fun updateFilters(filter: AsteroidsFilter) {
+            _filter.value = filter
         }
     }
-}


### PR DESCRIPTION
## Summary

- Second of three Hilt sub-PRs. Moves the DB + repository + `MainViewModel` graph onto Hilt while leaving `RefreshDataWorker` and `getDatabase()` in place — those are 5c.
- New `di/DatabaseModule` provides `AsteroidDatabase` (delegating to `getDatabase()` so :app and the worker share one Room instance), `AsteroidDao`, and `AsteroidRepository` as `@Provides @Singleton`.
- `MainViewModel` is `@HiltViewModel` with a constructor-injected `AsteroidRepository`; the inner `Factory` and `AndroidViewModel(application)` plumbing are gone.
- `MainActivity`, `MainFragment`, and `DetailFragment` get `@AndroidEntryPoint`. `MainFragment` switches to plain `by viewModels()`.

## Test plan

- [x] `./gradlew spotlessCheck detekt` — green
- [x] `./gradlew lintRelease assembleDebug test` — green
- [ ] CI build job green on the PR
- [ ] Device smoke deferred to the combined Phase 4/5 cut (per the improvement plan, sub-PRs don't tag individually)

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)