### PR TITLE
feat: migrate RefreshDataWorker to Hilt + apply LoD to repository (Phase 5c)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -142,6 +142,11 @@ dependencies {
     ksp(libs.androidx.room.compiler)
 
     implementation(libs.androidx.work.runtime.ktx)
+    // androidx-hilt:hilt-work is a separate artifact group from the dagger-hilt
+    // ones (which the convention plugin wires); the matching compiler is also
+    // distinct and goes through KSP, not kapt.
+    implementation(libs.androidx.hilt.work)
+    ksp(libs.androidx.hilt.compiler)
 
     implementation(libs.coil)
     implementation(libs.timber)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,7 +28,8 @@
   ~ if you submit it, it's your own responsibility if you get expelled.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -59,6 +60,21 @@
                 android:name="autoStoreLocales"
                 android:value="true" />
         </service>
+
+        <!-- Strip androidx.startup's default WorkManagerInitializer; WorkManager.getInstance()
+             must lazily read workManagerConfiguration AFTER Hilt populates workerFactory in
+             Application.onCreate, otherwise lateinit factory NPEs and Hilt-injected workers
+             fall back to the default factory and fail with "could not instantiate". -->
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            android:exported="false"
+            tools:node="merge">
+            <meta-data
+                android:name="androidx.work.WorkManagerInitializer"
+                android:value="androidx.startup"
+                tools:node="remove" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/tarek/asteroidradar/AsteroidRadarApplication.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/AsteroidRadarApplication.kt
@@ -29,6 +29,8 @@
 package com.tarek.asteroidradar
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
@@ -41,10 +43,25 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.util.concurrent.TimeUnit
+import javax.inject.Inject
 
 @HiltAndroidApp
-class AsteroidRadarApplication : Application() {
+class AsteroidRadarApplication :
+    Application(),
+    Configuration.Provider {
     private val applicationScope = CoroutineScope(Dispatchers.Default)
+
+    @Inject lateinit var workerFactory: HiltWorkerFactory
+
+    // The default WorkManagerInitializer is removed in the manifest so this
+    // is read by WorkManager.getInstance() lazily — after Hilt has populated
+    // workerFactory in onCreate. Reading it earlier would NPE the lateinit.
+    override val workManagerConfiguration: Configuration
+        get() =
+            Configuration
+                .Builder()
+                .setWorkerFactory(workerFactory)
+                .build()
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/tarek/asteroidradar/database/AsteroidDatabase.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/database/AsteroidDatabase.kt
@@ -28,39 +28,10 @@
  */
 package com.tarek.asteroidradar.database
 
-import android.content.Context
 import androidx.room.Database
-import androidx.room.Room
 import androidx.room.RoomDatabase
 
-/**
- * A database that stores DatabaseAsteroid information.
- * And a global method to get access to the database.
- *
- * This pattern is pretty much the same for any database,
- * so you can reuse it.
- */
 @Database(entities = [DatabaseAsteroid::class], version = 1)
 abstract class AsteroidDatabase : RoomDatabase() {
-    /**
-     * Connects the database to the DAO.
-     */
     abstract val asteroidDao: AsteroidDao
-}
-
-private lateinit var instance: AsteroidDatabase
-
-fun getDatabase(context: Context): AsteroidDatabase {
-    synchronized(AsteroidDatabase::class.java) {
-        if (!::instance.isInitialized) {
-            instance =
-                Room
-                    .databaseBuilder(
-                        context.applicationContext,
-                        AsteroidDatabase::class.java,
-                        "asteroids",
-                    ).build()
-        }
-    }
-    return instance
 }

--- a/app/src/main/java/com/tarek/asteroidradar/di/DatabaseModule.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/di/DatabaseModule.kt
@@ -29,9 +29,9 @@
 package com.tarek.asteroidradar.di
 
 import android.content.Context
+import androidx.room.Room
 import com.tarek.asteroidradar.database.AsteroidDao
 import com.tarek.asteroidradar.database.AsteroidDatabase
-import com.tarek.asteroidradar.database.getDatabase
 import com.tarek.asteroidradar.repository.AsteroidRepository
 import dagger.Module
 import dagger.Provides
@@ -40,11 +40,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Singleton
 
-// Hilt module for database + repository graph. Phase 5b only — `getDatabase()`
-// is intentionally kept as the construction site so :app (via Hilt) and
-// `RefreshDataWorker` (still pre-Hilt this phase) share a single Room instance.
-// Phase 5c migrates the worker, deletes `getDatabase()`, and inlines
-// `Room.databaseBuilder(...)` here.
 @Module
 @InstallIn(SingletonComponent::class)
 object DatabaseModule {
@@ -52,12 +47,18 @@ object DatabaseModule {
     @Singleton
     fun provideAsteroidDatabase(
         @ApplicationContext context: Context,
-    ): AsteroidDatabase = getDatabase(context)
+    ): AsteroidDatabase =
+        Room
+            .databaseBuilder(
+                context,
+                AsteroidDatabase::class.java,
+                "asteroids",
+            ).build()
 
     @Provides
     fun provideAsteroidDao(database: AsteroidDatabase): AsteroidDao = database.asteroidDao
 
     @Provides
     @Singleton
-    fun provideAsteroidRepository(database: AsteroidDatabase): AsteroidRepository = AsteroidRepository(database)
+    fun provideAsteroidRepository(asteroidDao: AsteroidDao): AsteroidRepository = AsteroidRepository(asteroidDao)
 }

--- a/app/src/main/java/com/tarek/asteroidradar/repository/AsteroidRepository.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/repository/AsteroidRepository.kt
@@ -31,7 +31,7 @@ package com.tarek.asteroidradar.repository
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.map
 import com.tarek.asteroidradar.BuildConfig
-import com.tarek.asteroidradar.database.AsteroidDatabase
+import com.tarek.asteroidradar.database.AsteroidDao
 import com.tarek.asteroidradar.database.asDomainModel
 import com.tarek.asteroidradar.domain.Asteroid
 import com.tarek.asteroidradar.domain.PictureOfDay
@@ -46,7 +46,7 @@ import timber.log.Timber
 import java.time.LocalDate
 
 class AsteroidRepository(
-    private val database: AsteroidDatabase,
+    private val asteroidDao: AsteroidDao,
 ) {
     sealed class AsteroidsFilter {
         data object TODAY : AsteroidsFilter()
@@ -67,17 +67,17 @@ class AsteroidRepository(
     fun getAsteroidSelection(filter: AsteroidsFilter): LiveData<List<Asteroid>> =
         when (filter) {
             AsteroidsFilter.STORED ->
-                database.asteroidDao.getAsteroids().map {
+                asteroidDao.getAsteroids().map {
                     it.asDomainModel()
                 }
 
             AsteroidsFilter.WEEK ->
-                database.asteroidDao.getWeeklyAsteroids(startDate, endDate).map {
+                asteroidDao.getWeeklyAsteroids(startDate, endDate).map {
                     it.asDomainModel()
                 }
 
             AsteroidsFilter.TODAY ->
-                database.asteroidDao.getTodayAsteroids(startDate).map {
+                asteroidDao.getTodayAsteroids(startDate).map {
                     it.asDomainModel()
                 }
         }
@@ -95,7 +95,7 @@ class AsteroidRepository(
             try {
                 val asteroidsJson =
                     AsteroidApi.retrofitService.getAsteroids(API_KEY)
-                database.asteroidDao.insertAll(
+                asteroidDao.insertAll(
                     *parseAsteroidsJsonResult(JSONObject(asteroidsJson))
                         .asDatabaseModel(),
                 )
@@ -106,6 +106,6 @@ class AsteroidRepository(
     }
 
     suspend fun deletePastAsteroids() {
-        database.asteroidDao.deletePreviousAsteroid(startDate)
+        asteroidDao.deletePreviousAsteroid(startDate)
     }
 }

--- a/app/src/main/java/com/tarek/asteroidradar/work/RefreshDataWorker.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/work/RefreshDataWorker.kt
@@ -29,32 +29,35 @@
 package com.tarek.asteroidradar.work
 
 import android.content.Context
+import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
-import com.tarek.asteroidradar.database.getDatabase
 import com.tarek.asteroidradar.repository.AsteroidRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import retrofit2.HttpException
 
-class RefreshDataWorker(
-    appContext: Context,
-    params: WorkerParameters,
-) : CoroutineWorker(
-        appContext,
-        params,
-    ) {
-    companion object {
-        const val WORK_NAME = "RefreshDataWorker"
-    }
-
-    override suspend fun doWork(): Result {
-        val database = getDatabase(applicationContext)
-        val repository = AsteroidRepository(database)
-        return try {
-            repository.deletePastAsteroids()
-            repository.refreshAsteroids()
-            Result.success()
-        } catch (e: HttpException) {
-            Result.retry()
+@HiltWorker
+class RefreshDataWorker
+    @AssistedInject
+    constructor(
+        @Assisted appContext: Context,
+        @Assisted params: WorkerParameters,
+        private val repository: AsteroidRepository,
+    ) : CoroutineWorker(
+            appContext,
+            params,
+        ) {
+        companion object {
+            const val WORK_NAME = "RefreshDataWorker"
         }
+
+        override suspend fun doWork(): Result =
+            try {
+                repository.deletePastAsteroids()
+                repository.refreshAsteroids()
+                Result.success()
+            } catch (e: HttpException) {
+                Result.retry()
+            }
     }
-}

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -14,8 +14,8 @@ shippable; pick them off in order — each one stacks on the last.
 | 2 | Convention plugin (`build-logic/`) | Done (#54) |
 | 3 | Code-quality plumbing (Spotless / Detekt / Lint) | Done (#56, #58, #60) |
 | 4 | Toolchain modernization (Kotlin 2.x, AndroidX bumps, Picasso → Coil) | Done (#62, #64, #66) — manual device smoke pending |
-| 5 | Hilt | **Next** |
-| 6 | Production hardening (R8, fail-fast on missing API key) | Pending |
+| 5 | Hilt | Done (#80, #82, #84) — manual device smoke pending |
+| 6 | Production hardening (R8, fail-fast on missing API key) | **Next** |
 | 7 | Tests + Kover | Pending |
 | 8 | Edge-to-edge | Pending |
 | 9 | Compose migration | Deferred |

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ androidxAppcompat = "1.7.0"
 androidxConstraintlayout = "2.2.0"
 androidxCore = "1.15.0"
 androidxFragment = "1.8.5"
+# androidx.hilt:* (hilt-work, hilt-compiler) is a separate artifact group from
+# com.google.dagger:hilt-*; KSP-supported since 1.2.0.
+androidxHilt = "1.2.0"
 androidxLifecycle = "2.8.7"
 androidxRecyclerview = "1.4.0"
 # Room 2.8.x requires AGP >= 8.5; staying on 2.7.x until the AGP bump PR.
@@ -54,6 +57,9 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidxConstraintlayout" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidxFragment" }
+
+androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidxHilt" }
+androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "androidxHilt" }
 
 androidx-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }


### PR DESCRIPTION
## Summary

Final Hilt sub-PR — wraps Phase 5 by migrating `RefreshDataWorker` into the DI graph, deleting the `getDatabase()` global, and folding in the `AsteroidRepository` Law-of-Demeter fix while the repo's construction site was already on the operating table.

- `RefreshDataWorker` is now `@HiltWorker` with `@AssistedInject` framework params + an injected `AsteroidRepository`. `Configuration.Provider` is implemented on `AsteroidRadarApplication`; the default `WorkManagerInitializer` is stripped from the manifest so `WorkManager.getInstance()` lazily reads `workManagerConfiguration` *after* Hilt has populated `workerFactory`.
- `getDatabase()` + `lateinit instance` are gone — `DatabaseModule.provideAsteroidDatabase` calls `Room.databaseBuilder` directly.
- `AsteroidRepository` now takes `AsteroidDao` instead of `AsteroidDatabase`. Five `database.asteroidDao.X()` train wrecks become direct DAO calls; Hilt resolves the new ctor via the existing `provideAsteroidDao` provider.
- New deps: `androidx.hilt:hilt-work` + `androidx.hilt:hilt-compiler` (1.2.0, KSP). Wired in `:app`'s dependencies block — kept out of the `asteroidradar.android.hilt` convention plugin since worker support is per-module.

Fixes #83

## Test plan

- [x] `./gradlew spotlessCheck detekt lintRelease assembleDebug test` — all green locally
- [ ] Install debug APK on device, launch the app — `MainFragment` populates, APOD image loads (validates `Configuration.Provider` cold start)
- [ ] Force the worker via `adb shell cmd jobscheduler run -f com.tarek.asteroidradar 0` (or WorkManager Inspector) — confirm no `Could not instantiate RefreshDataWorker` and no fall-back-to-default-factory complaints in LogCat

🤖 Generated with [Claude Code](https://claude.com/claude-code)