### PR TITLE
Phase 7b: JVM tests for AsteroidRepository, MainViewModel, and parser edge cases

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -170,6 +170,10 @@ dependencies {
     implementation(libs.timber)
 
     testImplementation(libs.bundles.test.shared)
+    // arch-core-testing brings InstantTaskExecutorRule for synchronous LiveData
+    // tests; only the repo + ViewModel tests need it, so keep it out of the
+    // shared bundle.
+    testImplementation(libs.androidx.arch.core.testing)
     testImplementation(libs.org.json)
     androidTestImplementation(libs.bundles.android.test)
 }

--- a/app/src/test/java/com/tarek/asteroidradar/network/ParseAsteroidsJsonResultTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/network/ParseAsteroidsJsonResultTest.kt
@@ -30,9 +30,11 @@ package com.tarek.asteroidradar.network
 
 import com.tarek.asteroidradar.util.Constants
 import org.json.JSONArray
+import org.json.JSONException
 import org.json.JSONObject
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertThrows
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.text.SimpleDateFormat
@@ -85,6 +87,92 @@ class ParseAsteroidsJsonResultTest {
             assertEquals(DEFAULT_VELOCITY_KM_PER_SEC, relativeVelocity, 0.0001)
             assertEquals(DEFAULT_MISS_AU, distanceFromEarth, 0.0001)
             assertTrue(isPotentiallyHazardous)
+        }
+    }
+
+    @Test
+    fun `parses multiple asteroids on the same date`() {
+        val dates = expectedDateWindow()
+        val today = dates.first()
+        val payload =
+            JSONObject().put(
+                "near_earth_objects",
+                JSONObject().apply {
+                    put(
+                        today,
+                        JSONArray()
+                            .put(populatedAsteroidJson(today, id = 1))
+                            .put(populatedAsteroidJson(today, id = 2))
+                            .put(populatedAsteroidJson(today, id = 3)),
+                    )
+                    dates.drop(1).forEach { put(it, JSONArray()) }
+                },
+            )
+
+        val parsed = parseAsteroidsJsonResult(payload)
+
+        assertEquals(3, parsed.size)
+        assertEquals(listOf(1L, 2L, 3L), parsed.map { it.id })
+        assertTrue(parsed.all { it.closeApproachDate == today })
+    }
+
+    @Test
+    fun `returns empty list when every date has no asteroids`() {
+        val dates = expectedDateWindow()
+        val payload =
+            JSONObject().put(
+                "near_earth_objects",
+                JSONObject().apply {
+                    dates.forEach { put(it, JSONArray()) }
+                },
+            )
+
+        val parsed = parseAsteroidsJsonResult(payload)
+
+        assertTrue(parsed.isEmpty())
+    }
+
+    @Test
+    fun `uses only the first close_approach_data entry`() {
+        // The API can return multiple close-approach windows per asteroid; the
+        // parser intentionally reads element 0 only. Lock that contract.
+        val dates = expectedDateWindow()
+        val today = dates.first()
+        val asteroid =
+            populatedAsteroidJson(today).apply {
+                val extraApproach =
+                    JSONObject().apply {
+                        put("close_approach_date", today)
+                        put(
+                            "relative_velocity",
+                            JSONObject().put("kilometers_per_second", 999.99),
+                        )
+                        put("miss_distance", JSONObject().put("astronomical", 999.99))
+                    }
+                getJSONArray("close_approach_data").put(extraApproach)
+            }
+        val payload =
+            JSONObject().put(
+                "near_earth_objects",
+                JSONObject().apply {
+                    put(today, JSONArray().put(asteroid))
+                    dates.drop(1).forEach { put(it, JSONArray()) }
+                },
+            )
+
+        val parsed = parseAsteroidsJsonResult(payload)
+
+        assertEquals(1, parsed.size)
+        assertEquals(DEFAULT_VELOCITY_KM_PER_SEC, parsed.first().relativeVelocity, 0.0001)
+        assertEquals(DEFAULT_MISS_AU, parsed.first().distanceFromEarth, 0.0001)
+    }
+
+    @Test
+    fun `throws JSONException when near_earth_objects is missing`() {
+        val payload = JSONObject()
+
+        assertThrows(JSONException::class.java) {
+            parseAsteroidsJsonResult(payload)
         }
     }
 

--- a/app/src/test/java/com/tarek/asteroidradar/repository/AsteroidRepositoryTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/repository/AsteroidRepositoryTest.kt
@@ -1,0 +1,144 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.repository
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.google.common.truth.Truth.assertThat
+import com.tarek.asteroidradar.database.AsteroidDao
+import com.tarek.asteroidradar.database.DatabaseAsteroid
+import com.tarek.asteroidradar.database.asDomainModel
+import com.tarek.asteroidradar.repository.AsteroidRepository.AsteroidsFilter
+import com.tarek.asteroidradar.testing.getOrAwaitValue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.time.LocalDate
+
+class AsteroidRepositoryTest {
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private lateinit var dao: FakeAsteroidDao
+    private lateinit var repository: AsteroidRepository
+
+    @Before
+    fun setUp() {
+        dao = FakeAsteroidDao()
+        repository = AsteroidRepository(dao)
+    }
+
+    @Test
+    fun `STORED filter observes getAsteroids and maps to domain`() {
+        val entities = listOf(asteroidEntity(id = 1L), asteroidEntity(id = 2L))
+        dao.allLive.value = entities
+
+        val result = repository.getAsteroidSelection(AsteroidsFilter.STORED).getOrAwaitValue()
+
+        assertThat(result).isEqualTo(entities.asDomainModel())
+    }
+
+    @Test
+    fun `WEEK filter observes getWeeklyAsteroids with a 7-day window`() {
+        val entities = listOf(asteroidEntity(id = 1L))
+        dao.weeklyLive.value = entities
+
+        val result = repository.getAsteroidSelection(AsteroidsFilter.WEEK).getOrAwaitValue()
+
+        assertThat(result).isEqualTo(entities.asDomainModel())
+        val captured = checkNotNull(dao.getWeeklyCalledWith)
+        val start = LocalDate.parse(captured.first)
+        val end = LocalDate.parse(captured.second)
+        assertThat(start.plusDays(7)).isEqualTo(end)
+    }
+
+    @Test
+    fun `TODAY filter observes getTodayAsteroids with today's date`() {
+        val entities = listOf(asteroidEntity(id = 1L))
+        dao.todayLive.value = entities
+
+        val result = repository.getAsteroidSelection(AsteroidsFilter.TODAY).getOrAwaitValue()
+
+        assertThat(result).isEqualTo(entities.asDomainModel())
+        val captured = checkNotNull(dao.getTodayCalledWith)
+        // Repository captures `LocalDate.now()` at construction time; the test
+        // runs in the same process moments later, so the values must agree.
+        assertThat(LocalDate.parse(captured)).isEqualTo(LocalDate.now())
+    }
+
+    private fun asteroidEntity(
+        id: Long,
+        date: String = LocalDate.now().toString(),
+    ): DatabaseAsteroid =
+        DatabaseAsteroid(
+            id = id,
+            codename = "(2024 AB$id)",
+            closeApproachDate = date,
+            absoluteMagnitude = 19.5,
+            estimatedDiameter = 0.42,
+            relativeVelocity = 11.7,
+            distanceFromEarth = 0.025,
+            isPotentiallyHazardous = id % 2L == 0L,
+        )
+}
+
+private class FakeAsteroidDao : AsteroidDao {
+    val allLive = MutableLiveData<List<DatabaseAsteroid>>()
+    val todayLive = MutableLiveData<List<DatabaseAsteroid>>()
+    val weeklyLive = MutableLiveData<List<DatabaseAsteroid>>()
+
+    var getTodayCalledWith: String? = null
+        private set
+    var getWeeklyCalledWith: Pair<String, String>? = null
+        private set
+
+    override fun getAsteroids(): LiveData<List<DatabaseAsteroid>> = allLive
+
+    override fun getTodayAsteroids(today: String): LiveData<List<DatabaseAsteroid>> {
+        getTodayCalledWith = today
+        return todayLive
+    }
+
+    override fun getWeeklyAsteroids(
+        startDate: String,
+        endDate: String,
+    ): LiveData<List<DatabaseAsteroid>> {
+        getWeeklyCalledWith = startDate to endDate
+        return weeklyLive
+    }
+
+    override fun insertAll(vararg asteroids: DatabaseAsteroid) {
+        error("not used in this test")
+    }
+
+    override suspend fun deletePreviousAsteroid(today: String) {
+        error("not used in this test")
+    }
+}

--- a/app/src/test/java/com/tarek/asteroidradar/testing/LiveDataTestUtil.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/testing/LiveDataTestUtil.kt
@@ -1,0 +1,63 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.testing
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+// Standard arch-components LiveData test helper. Pairs with InstantTaskExecutorRule
+// to read the next emission synchronously; throws if no value arrives in `time`.
+fun <T> LiveData<T>.getOrAwaitValue(
+    time: Long = 2,
+    unit: TimeUnit = TimeUnit.SECONDS,
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer =
+        object : Observer<T> {
+            override fun onChanged(value: T) {
+                data = value
+                latch.countDown()
+                this@getOrAwaitValue.removeObserver(this)
+            }
+        }
+    observeForever(observer)
+    try {
+        if (!latch.await(time, unit)) {
+            throw TimeoutException("LiveData value was never set within $time $unit")
+        }
+    } finally {
+        removeObserver(observer)
+    }
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/app/src/test/java/com/tarek/asteroidradar/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/ui/main/MainViewModelTest.kt
@@ -1,0 +1,167 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.ui.main
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
+import com.google.common.truth.Truth.assertThat
+import com.tarek.asteroidradar.domain.Asteroid
+import com.tarek.asteroidradar.domain.PictureOfDay
+import com.tarek.asteroidradar.repository.AsteroidRepository
+import com.tarek.asteroidradar.repository.AsteroidRepository.AsteroidsFilter
+import com.tarek.asteroidradar.testing.getOrAwaitValue
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainViewModelTest {
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var repository: AsteroidRepository
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        repository = mockk(relaxed = true)
+        // The init block calls both refresh paths; default both to no-op so the
+        // test owner only stubs what they care about.
+        coEvery { repository.refreshAsteroids() } returns Unit
+        coEvery { repository.getImageOfTheDay() } returns SAMPLE_IMAGE
+        every { repository.getAsteroidSelection(any()) } returns MutableLiveData(emptyList())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `init refreshes asteroids and fetches the image of the day`() =
+        runTest(testDispatcher) {
+            val viewModel = MainViewModel(repository)
+            advanceUntilIdle()
+
+            coVerify(exactly = 1) { repository.refreshAsteroids() }
+            coVerify(exactly = 1) { repository.getImageOfTheDay() }
+            assertThat(viewModel.imageOfTheDay.getOrAwaitValue()).isEqualTo(SAMPLE_IMAGE)
+        }
+
+    @Test
+    fun `getImageOfTheDay error path is swallowed and leaves no value`() =
+        runTest(testDispatcher) {
+            coEvery { repository.getImageOfTheDay() } throws RuntimeException("boom")
+
+            val viewModel = MainViewModel(repository)
+            advanceUntilIdle()
+
+            assertThat(viewModel.imageOfTheDay.value).isNull()
+        }
+
+    @Test
+    fun `updateFilters propagates to filter and asteroids switchMap`() =
+        runTest(testDispatcher) {
+            val today = MutableLiveData<List<Asteroid>>(emptyList())
+            val week = MutableLiveData<List<Asteroid>>(emptyList())
+            every { repository.getAsteroidSelection(AsteroidsFilter.TODAY) } returns today
+            every { repository.getAsteroidSelection(AsteroidsFilter.WEEK) } returns week
+
+            val viewModel = MainViewModel(repository)
+            advanceUntilIdle()
+
+            // The asteroids switchMap is lazy — it only re-evaluates while it has
+            // an active observer. Keep one attached for the duration of the
+            // filter changes so each updateFilters re-triggers the mapping.
+            val asteroidsObserver = Observer<List<Asteroid>> { /* drain emissions */ }
+            viewModel.asteroids.observeForever(asteroidsObserver)
+            try {
+                viewModel.updateFilters(AsteroidsFilter.TODAY)
+                assertThat(viewModel.filter.value).isEqualTo(AsteroidsFilter.TODAY)
+                assertThat(viewModel.asteroids.value).isEmpty()
+
+                viewModel.updateFilters(AsteroidsFilter.WEEK)
+                assertThat(viewModel.filter.value).isEqualTo(AsteroidsFilter.WEEK)
+                assertThat(viewModel.asteroids.value).isEmpty()
+            } finally {
+                viewModel.asteroids.removeObserver(asteroidsObserver)
+            }
+
+            verify(exactly = 1) { repository.getAsteroidSelection(AsteroidsFilter.TODAY) }
+            verify(exactly = 1) { repository.getAsteroidSelection(AsteroidsFilter.WEEK) }
+        }
+
+    @Test
+    fun `onAsteroidClicked sets navigateToDetail and onAsteroidDetailNavigated clears it`() =
+        runTest(testDispatcher) {
+            val viewModel = MainViewModel(repository)
+            advanceUntilIdle()
+
+            viewModel.onAsteroidClicked(SAMPLE_ASTEROID)
+            assertThat(viewModel.navigateToDetail.getOrAwaitValue()).isEqualTo(SAMPLE_ASTEROID)
+
+            viewModel.onAsteroidDetailNavigated()
+            assertThat(viewModel.navigateToDetail.value).isNull()
+        }
+
+    private companion object {
+        val SAMPLE_IMAGE =
+            PictureOfDay(
+                mediaType = "image",
+                title = "Test image",
+                url = "https://example.invalid/apod.jpg",
+            )
+        val SAMPLE_ASTEROID =
+            Asteroid(
+                id = 42L,
+                codename = "(2024 ZZ1)",
+                closeApproachDate = "2024-01-01",
+                absoluteMagnitude = 19.5,
+                estimatedDiameter = 0.42,
+                relativeVelocity = 11.7,
+                distanceFromEarth = 0.025,
+                isPotentiallyHazardous = true,
+            )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,9 @@ ksp = "2.0.21-1.0.27"
 androidxNavigation = "2.8.5"
 
 androidxAppcompat = "1.7.0"
+# androidx.arch.core:core-testing is the InstantTaskExecutorRule that swaps the
+# LiveData main-thread executor for a synchronous one. JVM-only test dep.
+androidxArchCoreTesting = "2.2.0"
 androidxConstraintlayout = "2.2.0"
 androidxCore = "1.15.0"
 androidxFragment = "1.8.5"
@@ -59,6 +62,7 @@ spotless = "8.4.0"
 
 [libraries]
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppcompat" }
+androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidxArchCoreTesting" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidxConstraintlayout" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidxFragment" }


### PR DESCRIPTION
## Summary

- New JVM unit tests on the `test-shared` bundle wired in Phase 7a (#88, #89): repository filter mapping with a fake DAO, `MainViewModel` state transitions with MockK + Truth, parser edge cases.
- Adds `androidx.arch.core:core-testing` as a one-off `testImplementation` so `InstantTaskExecutorRule` is available — kept out of the shared bundle since only LiveData-touching tests need it.

Fixes #90

## What's tested

- **`AsteroidRepositoryTest`** (`FakeAsteroidDao` covering all four DAO methods)
  - `STORED` observes `getAsteroids()` and pipes through `asDomainModel()`.
  - `WEEK` observes `getWeeklyAsteroids(start, end)` with a 7-day window.
  - `TODAY` observes `getTodayAsteroids(today)` with `LocalDate.now()`.
- **`MainViewModelTest`** (MockK on `AsteroidRepository`, `StandardTestDispatcher` for `Dispatchers.Main`)
  - `init` runs both refresh paths and posts `imageOfTheDay`.
  - `getImageOfTheDay()` error path is swallowed.
  - `updateFilters` propagates through the `switchMap` (keeps an `observeForever` active to keep the switchMap alive across filter changes).
  - `onAsteroidClicked` / `onAsteroidDetailNavigated` toggle `navigateToDetail`.
- **`ParseAsteroidsJsonResultTest` extensions**
  - Multiple asteroids on the same date, all parsed.
  - All-empty `near_earth_objects` returns empty list, doesn't throw.
  - Only the first `close_approach_data` entry is used (locks current parser contract at `NetworkUtils.kt:62`).
  - Missing `near_earth_objects` key throws `JSONException`.

## Test plan

- [x] `./gradlew spotlessCheck detekt :app:lintRelease :app:testDebugUnitTest :app:koverHtmlReport` clean locally.
- [x] All 19 unit tests green (was 4 in Phase 7a).
- [ ] CI passes on PR.
- [ ] Open `app/build/reports/kover/html/index.html` after CI to confirm coverage lift on `repository/AsteroidRepository.kt`, `ui/main/MainViewModel.kt`, and `network/NetworkUtils.kt`.

## Non-goals (per the issue)

- Not testing `refreshAsteroids` / `getImageOfTheDay` network paths — those go through the `AsteroidApi` object singleton; revisit when network becomes constructor-injectable.
- No `koverVerify` gate yet (lands after 7c per the plan).
- `Example*Test` shells stay until 7c truly replaces them.
- No `versionMajor/Minor/Patch` bump — Phase 7 stacks into the eventual `v2.0.0-INTERNAL` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)