### PR TITLE
Phase 7 follow-up: koverVerify with a 60% INSTRUCTION floor

### DIFF
--- a/.github/workflows/build_pull_request.yml
+++ b/.github/workflows/build_pull_request.yml
@@ -116,10 +116,13 @@ jobs:
       - name: Run unit tests
         run: ./gradlew test
 
-      - name: Generate Kover coverage report
-        # No coverage gate yet; report is informational until 7b/7c land real
-        # tests and `koverVerify` gets a soft floor (60% per the plan).
-        run: ./gradlew :app:koverHtmlReport
+      - name: Generate Kover coverage report and verify floor
+        # `koverVerify` enforces the 60% INSTRUCTION floor configured in
+        # `app/build.gradle.kts`. The HTML report runs in the same step so
+        # the artifact is available even when the verify gate fails — the
+        # uploader below has `if: always()` so a regression PR still gets
+        # the report attached for inspection.
+        run: ./gradlew :app:koverHtmlReport :app:koverVerify
 
       - name: Upload lint and test reports
         # Always upload — they're most useful when one of the gates above fails.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -78,6 +78,98 @@ gradle.taskGraph.whenReady {
     }
 }
 
+// Kover filters + verification floor. The 60% target lives in
+// docs/IMPROVEMENT_PLAN.md as the Phase 7 follow-up; the filters here scope
+// it to JVM-testable production code (parser, repo, domain, ViewModel).
+// Generated code (DataBinding, Hilt, Room *_Impl, safe-args) and pure-UI
+// classes (Activity / Fragments / Adapter / Worker / BindingAdapters) are
+// excluded — they need Espresso or on-device smoke, not unit tests, and
+// drown the signal at unfiltered totals (~11% instructions otherwise).
+kover {
+    reports {
+        filters {
+            excludes {
+                packages(
+                    // DataBinding scaffold packages (generated alongside the @{} expressions).
+                    "androidx.databinding",
+                    "androidx.databinding.library.baseAdapters",
+                    "com.tarek.asteroidradar.databinding",
+                    "com.tarek.asteroidradar.generated.callback",
+                    // DI bindings (DatabaseModule + generated). No logic to exercise.
+                    "com.tarek.asteroidradar.di",
+                    // UI not covered by JVM tests — Phase 8+ Espresso territory.
+                    "com.tarek.asteroidradar.ui.detail",
+                    "com.tarek.asteroidradar.util",
+                    "com.tarek.asteroidradar.work",
+                    // Hilt aggregator packages. Each is exact — no wildcard support in packages().
+                    "dagger.hilt.internal.aggregatedroot.codegen",
+                    "hilt_aggregated_deps",
+                )
+                classes(
+                    // Top-level Android entry points (in com.tarek.asteroidradar package alongside
+                    // subpackages, so listed by FQN rather than via packages()).
+                    "com.tarek.asteroidradar.AsteroidRadarApplication",
+                    "com.tarek.asteroidradar.AsteroidRadarApplication\$*",
+                    "com.tarek.asteroidradar.MainActivity",
+                    "com.tarek.asteroidradar.MainActivity\$*",
+                    "com.tarek.asteroidradar.DataBinderMapperImpl",
+                    "com.tarek.asteroidradar.DataBindingTriggerClass",
+                    // ui.main retains MainViewModel; everything else in the package is UI / generated.
+                    "com.tarek.asteroidradar.ui.main.MainFragment",
+                    "com.tarek.asteroidradar.ui.main.MainFragment\$*",
+                    "com.tarek.asteroidradar.ui.main.AsteroidAdapter",
+                    "com.tarek.asteroidradar.ui.main.AsteroidAdapter\$*",
+                    "com.tarek.asteroidradar.ui.main.AsteroidListener",
+                    // [sic] — typo in the source class name predates this PR.
+                    "com.tarek.asteroidradar.ui.main.AsteriodDiffCallback",
+                    // network: trim the un-unit-testable surfaces. The Retrofit service
+                    // interface, the converter factory, and the DTO/POJO file all need
+                    // MockWebServer or a wired Retrofit instance to exercise — out of scope
+                    // for the JVM test bundle. Parser (NetworkUtilsKt) stays in.
+                    "com.tarek.asteroidradar.network.AsteroidApi",
+                    "com.tarek.asteroidradar.network.AsteroidApi\$*",
+                    "com.tarek.asteroidradar.network.AsteroidApiService",
+                    "com.tarek.asteroidradar.network.HandleScalarAndJsonConverterFactory",
+                    "com.tarek.asteroidradar.network.HandleScalarAndJsonConverterFactory\$*",
+                    "com.tarek.asteroidradar.network.ScalarResponse",
+                    "com.tarek.asteroidradar.network.JsonResponse",
+                    "com.tarek.asteroidradar.network.ImageOfTheDay",
+                    "com.tarek.asteroidradar.network.DataTransferObjectsKt",
+                    // Generated code patterns. `**` matches any chars including dots so the
+                    // pattern catches cross-package classes; plain `*` only matches within a
+                    // single FQN segment in Kover's globs (which is why `Hilt_*` alone misses
+                    // `com.tarek.asteroidradar.Hilt_MainActivity`).
+                    "**_Factory",
+                    "**_Factory\$*",
+                    "**_HiltModules*",
+                    "**_HiltComponents*",
+                    "**Hilt_*",
+                    "**_GeneratedInjector",
+                    "**_MembersInjector",
+                    "**_Impl",
+                    "**_Impl\$*",
+                    "**BindingImpl",
+                    "**BindingImpl\$*",
+                    "**.BR",
+                    "**Args",
+                    "**Directions",
+                    "**.BuildConfig",
+                )
+            }
+        }
+        verify {
+            rule {
+                // INSTRUCTION is the most refactor-resilient coverage metric
+                // (line counts shift with formatting; method/class are too coarse).
+                bound {
+                    minValue = 60
+                    coverageUnits = kotlinx.kover.gradle.plugin.dsl.CoverageUnit.INSTRUCTION
+                }
+            }
+        }
+    }
+}
+
 android {
     namespace = "com.tarek.asteroidradar"
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -16,7 +16,7 @@ shippable; pick them off in order — each one stacks on the last.
 | 4 | Toolchain modernization (Kotlin 2.x, AndroidX bumps, Picasso → Coil) | Done (#62, #64, #66) — manual device smoke pending |
 | 5 | Hilt | Done (#80, #82, #84) |
 | 6 | Production hardening (R8, fail-fast on missing API key) | **In progress** — 6a (#87) shipped fail-fast + slim proguard; 6b (#86) enables R8 alongside the AGP bump |
-| 7 | Tests + Kover | **In progress** — 7a (#89) + 7b (#91) shipped; 7c (issue #92) adds the AsteroidDao instrumented test + deletes the `Example*Test` shells |
+| 7 | Tests + Kover | Done (#89, #91, #93) — `koverVerify` 60% INSTRUCTION floor wired in the post-7c follow-up (issue #94) |
 | 8 | Edge-to-edge | Pending |
 | 9 | Compose migration | Deferred |
 | — | **Module split** lands with feature #2, not as a phase | — |
@@ -264,9 +264,14 @@ build-script changes.
   test using in-memory Room — `getAsteroids`, `getTodayAsteroids`,
   `getWeeklyAsteroids`, `deletePreviousAsteroid`. Empty `Example*Test`
   shells get deleted in this PR (truly replaced now).
-- **After 7c:** turn on `koverVerify` with a soft floor (60% per the plan),
-  ratchet up. XML report (Codecov / SonarCloud) is a future thing — still
-  a non-goal for the phase.
+- **After 7c — done.** `koverVerify` enforces a 60% INSTRUCTION floor on a
+  filtered scope (parser, repo, domain, ViewModel, DAO entities). Generated
+  code (DataBinding, Hilt, Room `*_Impl`, safe-args) and pure-UI surfaces
+  (Application/Activity/Fragments/Adapter/Worker/BindingAdapters) are
+  excluded — they need Espresso or on-device smoke, not unit tests. Filter
+  list lives in `app/build.gradle.kts`. Ratchet up the floor when future
+  test PRs raise the actual coverage. XML report (Codecov / SonarCloud) is
+  still a non-goal for the phase.
 
 ## Phase 8 — Edge-to-edge
 


### PR DESCRIPTION
## Summary

- Add Kover filter list + `koverVerify` rule in `app/build.gradle.kts`. Floor is 60% INSTRUCTION coverage on a filtered scope (parser, repo, domain, ViewModel, DAO entities). Generated code (DataBinding, Hilt, Room `*_Impl`, safe-args, `BuildConfig`) and pure-UI surfaces (Application/Activity/Fragments/Adapter/Worker/BindingAdapters) are excluded — they need Espresso or on-device smoke, not unit tests.
- Combine `koverHtmlReport` + `koverVerify` into one CI step. Existing `if: always()` artifact upload keeps the report attached on failure so a regression PR can still be inspected.
- Mark Phase 7 **Done** in `docs/IMPROVEMENT_PLAN.md`; replace the "After 7c" bullet with the landed gate description.

Fixes #94.

## Coverage at the floor

Current filtered INSTRUCTION coverage: **65.5%** (485/740). 5.5pp margin above the 60% floor — future test PRs ratchet up.

| Package | Instructions | Coverage |
|---|---|---|
| `database` (entities + extensions) | 71 | 97.2% |
| `domain` | 60 | 98.3% |
| `network` (parser + ServiceKt) | 159 | 86.8% |
| `repository` | 198 | 40.4% |
| `ui.main` (MainViewModel + inner classes) | 208 | 66.8% |
| `<top-level>` (DataBinderMapperImpl stragglers) | 44 | 0% |

Repository sits at 40.4% because `getImageOfTheDay`, `refreshAsteroids`, `deletePastAsteroids` aren't unit-testable without MockWebServer — they hit `AsteroidApi.retrofitService` directly. Future MockWebServer-style infra would lift this; out of scope for the floor PR.

## Test plan

- [x] `./gradlew spotlessCheck detekt lintRelease assembleDebug test :app:koverHtmlReport :app:koverVerify` — all pass.
- [x] Sanity-checked failure mode: setting `minValue = 70` produced `Rule violated: instructions covered percentage is 65.540500, but expected minimum is 70`. Reverted to 60.
- [ ] CI green on the PR build (this run will also upload a fresh `kover-report` artifact to inspect).

## Notes for reviewers

- Kover 0.9.x glob semantics: `*` does not cross `.`, so cross-package patterns need `**` (e.g. `**Hilt_*` instead of `Hilt_*`). `packages()` is exact-match (no wildcard support) — `dagger.hilt.internal.*` as a package name silently does nothing; subpackages have to be listed individually.
- `packages("com.tarek.asteroidradar")` also turned out to be prefix-match in practice (it killed the entire app namespace). Top-level Application + MainActivity are listed as class FQNs instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)