### PR TITLE
docs: tick Phase 8 as done in IMPROVEMENT_PLAN

### DIFF
--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -17,7 +17,7 @@ shippable; pick them off in order — each one stacks on the last.
 | 5 | Hilt | Done (#80, #82, #84) |
 | 6 | Production hardening (R8, fail-fast on missing API key) | **In progress** — 6a (#87) shipped fail-fast + slim proguard; 6b (#86) enables R8 alongside the AGP bump |
 | 7 | Tests + Kover | Done (#89, #91, #93) — `koverVerify` 60% INSTRUCTION floor wired in the post-7c follow-up (issue #94) |
-| 8 | Edge-to-edge | Pending |
+| 8 | Edge-to-edge | Done (#97) — included a NoActionBar + Toolbar migration that the issue's non-goal #4 had ruled out |
 | 9 | Compose migration | Deferred |
 | — | **Module split** lands with feature #2, not as a phase | — |
 


### PR DESCRIPTION
## Summary

- Flip the Phase 8 status row from **Pending** to **Done (#97)**, with a note that the merged scope folded in the NoActionBar + Toolbar migration that the original issue listed as a non-goal.

## Test plan

- [x] Docs-only diff (one line in `docs/IMPROVEMENT_PLAN.md`); CI's `detect` job will skip `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)