### PR TITLE
feat: add Compose convention plugin + BOM bundle (Phase 9a)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -34,6 +34,7 @@ import java.util.Properties
 // buildTypes, sourceSets, dataBinding).
 plugins {
     id("asteroidradar.android.application")
+    id("asteroidradar.android.compose")
     id("asteroidradar.android.hilt")
     alias(libs.plugins.kover)
 }
@@ -99,6 +100,10 @@ kover {
                     "com.tarek.asteroidradar.di",
                     // UI not covered by JVM tests — Phase 8+ Espresso territory.
                     "com.tarek.asteroidradar.ui.detail",
+                    // Phase 9a Compose smoke; 9b/9c will fold the surviving
+                    // Composables into the regular ui.detail / ui.main packages
+                    // and this entry can come out then.
+                    "com.tarek.asteroidradar.ui.compose",
                     "com.tarek.asteroidradar.util",
                     "com.tarek.asteroidradar.work",
                     // Hilt aggregator packages. Each is exact — no wildcard support in packages().
@@ -258,6 +263,18 @@ dependencies {
 
     implementation(libs.coil)
     implementation(libs.timber)
+
+    // Compose runtime: BOM aligns the androidx.compose.* artifacts; the bundle
+    // pulls in UI / Material 3 / activity-compose / lifecycle-runtime-compose /
+    // navigation-compose / hilt-navigation-compose / coil-compose. The
+    // ui-tooling sibling is debug-only (Layout Inspector + @Preview rendering).
+    implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.bundles.compose)
+    debugImplementation(libs.androidx.compose.ui.tooling)
+
+    // Mans0n compose-rules ruleset for detekt — Compose-specific checks
+    // (slot-table correctness, hoisting, parameter ordering, modifier handling).
+    detektPlugins(libs.detekt.compose.rules)
 
     testImplementation(libs.bundles.test.shared)
     // arch-core-testing brings InstantTaskExecutorRule for synchronous LiveData

--- a/app/src/main/java/com/tarek/asteroidradar/ui/compose/PhaseNineSmoke.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/ui/compose/PhaseNineSmoke.kt
@@ -1,0 +1,54 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.ui.compose
+
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+// Phase 9a smoke — confirms the Compose Compiler plugin runs end-to-end and
+// the BOM-aligned Material 3 artifact resolves. Deleted in Phase 9b once
+// DetailScreen ships real Composables.
+//
+// Suppressions cover three rules that all fire on this single throwaway
+// preview: ktlint's standard:function-naming + detekt's FunctionNaming both
+// flag PascalCase composables (composables are PascalCase by Compose
+// convention); UnusedPrivateMember flags @Preview functions that the IDE
+// invokes but the source code never calls. 9b/9c will configure detekt
+// project-wide for composables once we have many.
+@Preview
+@Composable
+@Suppress(
+    "FunctionNaming",
+    "UnusedPrivateMember",
+    "ktlint:standard:function-naming",
+)
+private fun PhaseNineSmoke() {
+    Text(text = "Compose foundation OK")
+}

--- a/build-logic/convention/src/main/kotlin/asteroidradar.android.compose.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/asteroidradar.android.compose.gradle.kts
@@ -20,29 +20,19 @@
  * SOFTWARE.
  */
 
+import com.android.build.api.dsl.ApplicationExtension
+
+// Phase 9a — Compose foundation. Apply on top of `asteroidradar.android.application`
+// in any module that hosts Composables. The Kotlin Compose Compiler ships as a
+// Kotlin plugin since 2.0 and its version tracks the Kotlin pin (no separate
+// Compose-Compiler ref). The androidx.compose.* artifact versions come from
+// `platform(libs.androidx.compose.bom)` in the consuming module's dependencies.
 plugins {
-    `kotlin-dsl`
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
-// Match the project JVM toolchain so the precompiled-script-plugin classes
-// load under the same Java version the rest of the build uses.
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
+extensions.configure<ApplicationExtension> {
+    buildFeatures {
+        compose = true
     }
-}
-
-// `implementation` (not `compileOnly`) because precompiled script plugins
-// resolve `id("com.android.application")` from the convention plugin's own
-// runtime classpath at apply time — `compileOnly` would satisfy the
-// type-safe-accessor compile step but leave Gradle unable to find the
-// plugin when a consuming module applies it. The AGP / Kotlin / KSP /
-// safe-args artifacts must be on `implementation` here.
-dependencies {
-    implementation(libs.android.gradle.plugin)
-    implementation(libs.kotlin.gradle.plugin)
-    implementation(libs.kotlin.compose.compiler.gradle.plugin)
-    implementation(libs.ksp.gradle.plugin)
-    implementation(libs.androidx.navigation.safeargs.gradle.plugin)
-    implementation(libs.hilt.gradle.plugin)
 }

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -18,7 +18,7 @@ shippable; pick them off in order — each one stacks on the last.
 | 6 | Production hardening (R8, fail-fast on missing API key) | Done (#87, #100) — 6a fail-fast + slim proguard; 6b bundled AGP 8.3 → 8.7.3 + R8 + `shrinkResources` |
 | 7 | Tests + Kover | Done (#89, #91, #93) — `koverVerify` 60% INSTRUCTION floor wired in the post-7c follow-up (issue #94) |
 | 8 | Edge-to-edge | Done (#97) — included a NoActionBar + Toolbar migration that the issue's non-goal #4 had ruled out |
-| 9 | Compose migration | Pending |
+| 9 | Compose migration | **In progress** — 9a (#102) wires the convention plugin + BOM + bundle |
 | — | **Module split** lands with feature #2, not as a phase | — |
 
 Tick the table when phases land. Each phase below lists scope, rationale, and

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,10 @@ androidxNavigation = "2.8.5"
 
 androidxActivity = "1.10.1"
 androidxAppcompat = "1.7.0"
+# Compose BOM aligns the rest of the androidx.compose.* artifacts (Material 3,
+# UI, tooling). The activity/lifecycle/navigation/hilt-compose deps are
+# published outside the BOM and pin alongside their non-Compose siblings.
+androidxComposeBom = "2025.01.01"
 # androidx.arch.core:core-testing is the InstantTaskExecutorRule that swaps the
 # LiveData main-thread executor for a synchronous one. JVM-only test dep.
 androidxArchCoreTesting = "2.2.0"
@@ -52,6 +56,9 @@ truth = "1.4.5"
 turbine = "1.2.1"
 
 # Code-quality tooling. ktlint version pinned for reproducibility across machines.
+# Mans0n compose-rules ships a detekt-plugin variant for Compose-specific checks
+# (slot-table correctness, hoisting, parameter ordering, modifier handling).
+composeRules = "0.4.22"
 detekt = "1.23.8"
 # Kover 0.9.x supports Kotlin 2.0+; aligned with the project's Kotlin pin.
 kover = "0.9.2"
@@ -59,19 +66,31 @@ ktlint = "1.5.0"
 spotless = "8.4.0"
 
 [libraries]
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidxActivity" }
 androidx-activity-ktx = { module = "androidx.activity:activity-ktx", version.ref = "androidxActivity" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppcompat" }
+# Compose BOM constraint — individual androidx.compose.* artifacts below omit
+# their version since the BOM aligns them. Apply via `platform(...)` in the
+# consuming module.
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidxComposeBom" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+androidx-compose-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-arch-core-testing = { module = "androidx.arch.core:core-testing", version.ref = "androidxArchCoreTesting" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidxConstraintlayout" }
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
 androidx-fragment-ktx = { module = "androidx.fragment:fragment-ktx", version.ref = "androidxFragment" }
 
 androidx-hilt-compiler = { module = "androidx.hilt:hilt-compiler", version.ref = "androidxHilt" }
+androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "androidxHilt" }
 androidx-hilt-work = { module = "androidx.hilt:hilt-work", version.ref = "androidxHilt" }
 
 androidx-lifecycle-livedata-ktx = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "androidxLifecycle" }
+androidx-lifecycle-runtime-compose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
 
+androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "androidxNavigation" }
 androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidxNavigation" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidxNavigation" }
 
@@ -95,6 +114,8 @@ retrofit-converter-scalars = { module = "com.squareup.retrofit2:converter-scalar
 retrofit-coroutines-adapter = { module = "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter", version.ref = "retrofitCoroutinesAdapter" }
 
 coil = { module = "io.coil-kt:coil", version.ref = "coil" }
+coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+detekt-compose-rules = { module = "io.nlopez.compose.rules:detekt", version.ref = "composeRules" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
@@ -114,6 +135,7 @@ turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 # intentionally `version.ref`'d to the same refs used in [plugins] above so
 # there's no opportunity for plugin id ↔ classpath drift.
 android-gradle-plugin = { module = "com.android.tools.build:gradle", version.ref = "agp" }
+kotlin-compose-compiler-gradle-plugin = { module = "org.jetbrains.kotlin:compose-compiler-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 ksp-gradle-plugin = { module = "com.google.devtools.ksp:com.google.devtools.ksp.gradle.plugin", version.ref = "ksp" }
 androidx-navigation-safeargs-gradle-plugin = { module = "androidx.navigation:navigation-safe-args-gradle-plugin", version.ref = "androidxNavigation" }
@@ -133,6 +155,20 @@ lifecycle = [
 navigation = [
     "androidx-navigation-fragment-ktx",
     "androidx-navigation-ui-ktx",
+]
+# Compose runtime stack. Apply alongside `platform(libs.androidx.compose.bom)`
+# in the consuming module so the BOM aligns the androidx.compose.* artifacts.
+# `androidx-compose-ui-tooling` is a debug-only sibling and stays out of the
+# bundle (added as `debugImplementation` directly).
+compose = [
+    "androidx-activity-compose",
+    "androidx-compose-material3",
+    "androidx-compose-ui",
+    "androidx-compose-ui-tooling-preview",
+    "androidx-hilt-navigation-compose",
+    "androidx-lifecycle-runtime-compose",
+    "androidx-navigation-compose",
+    "coil-compose",
 ]
 # Retrofit + Moshi networking stack, including both response converters and
 # the Jake Wharton coroutines adapter that the legacy service uses.
@@ -168,6 +204,9 @@ test-shared = [
 android-application = { id = "com.android.application", version.ref = "agp" }
 androidx-navigation-safeargs = { id = "androidx.navigation.safeargs.kotlin", version.ref = "androidxNavigation" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+# The Kotlin Compose Compiler ships as a Kotlin plugin since Kotlin 2.0 — its
+# version tracks the Kotlin compiler pin, not a separate Compose Compiler ref.
+kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 # kapt is still applied because the DataBinding compiler discovers
 # @BindingAdapter methods via kapt — AGP 8.7's DataBinding-via-KSP path is
 # still experimental and didn't pick up our adapters cleanly. Phase 9c drops


### PR DESCRIPTION
## Summary

Foundation-only PR for Phase 9. **No user-visible change** — wires the Compose runtime into the build graph so 9b (`DetailScreen`) and 9c (`MainScreen` + Nav-Compose) can ship UI work without re-litigating catalog and convention-plugin choices.

- New `asteroidradar.android.compose` convention plugin: enables `buildFeatures.compose = true` and applies `org.jetbrains.kotlin.plugin.compose` (bundled with Kotlin 2.0+ — version-tracks the Kotlin pin).
- Catalog gains the BOM-aligned androidx.compose.* artifacts (UI, Material 3, tooling-preview), the non-BOM Compose-side libs (activity-compose, lifecycle-runtime-compose, navigation-compose, hilt-navigation-compose), `coil-compose`, the [Mans0n compose-rules](https://github.com/mrmans0n/compose-rules) detekt ruleset, and a new `[bundles] compose` entry.
- `:app` applies the convention, pulls in the bundle alongside `platform(libs.androidx.compose.bom)`, adds `ui-tooling` as `debugImplementation`, and picks up the compose-rules detekt ruleset via `detektPlugins`.
- One throwaway `@Preview` composable in `ui/compose/PhaseNineSmoke.kt` verifies the Compose Compiler plugin runs end-to-end and Material 3 resolves through the BOM. Deleted in 9b.

## Out of scope (per #102 / #99)

- Migrating `MainFragment` / `DetailFragment` to Composables — 9b + 9c.
- Dropping `kotlin-kapt` / `dataBinding = true` — 9c retires DataBinding entirely.
- Nav-Compose typed routes via kotlinx-serialization — 9c.

## Verification

```
./gradlew spotlessCheck detekt lintRelease assembleDebug assembleRelease test koverVerify
```

All green. The release build runs `minifyReleaseWithR8` + `shrinkReleaseRes` cleanly with the Compose runtime present (Compose's AAR consumer rules cover the new surface — no `proguard-rules.pro` additions needed).

No device smoke for 9a — the Compose runtime is dormant until 9b lands a real Composable hosted in the activity. The 5-step smoke from #86 returns in 9c.

## Notes for reviewers

- `PhaseNineSmoke` triple-suppresses `FunctionNaming` (detekt) + `UnusedPrivateMember` (detekt) + `ktlint:standard:function-naming` (ktlint). All three fire on PascalCase composables; tried `.editorconfig`'s `ktlint_function_naming_ignore_when_annotated_with` first but ktlint 1.5.0 didn't honor it. Once 9b/9c add many composables, the right move is project-wide detekt config (track separately).
- `ui.compose` is added to the Kover exclude list. The package goes away in 9b/9c when surviving composables move into `ui.detail` / `ui.main`; the exclude entry comes out then.
- IMPROVEMENT_PLAN row 9 flipped to **In progress**.

## Test plan

- [x] `./gradlew spotlessCheck detekt lintRelease assembleDebug assembleRelease test koverVerify` — all pass.
- [x] CI mirror: full PR-build workflow passes on the branch.

Fixes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)