### PR TITLE
Phase 11: kotlinx.serialization migration (drop Moshi + reflection)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,7 +44,7 @@ plugins {
 // .github/workflows/release.yml greps these names, so don't rename them.
 val versionMajor = 3
 val versionMinor = 0
-val versionPatch = 1
+val versionPatch = 2
 val versionClassifier = "INTERNAL"
 
 // versionCode formula uses minSdk as a high digit so a future minSdk bump
@@ -138,11 +138,6 @@ kover {
                     "com.tarek.asteroidradar.network.AsteroidApi\$*",
                     "com.tarek.asteroidradar.network.AsteroidService",
                     "com.tarek.asteroidradar.network.ImageOfTheDay",
-                    // Moshi codegen-generated adapter (issue #113 hotfix). Pure
-                    // synthetic JSON parser bytecode, equivalent of @JsonClass
-                    // metadata — no JVM-testable surface, exercised by the
-                    // on-device APOD render path.
-                    "com.tarek.asteroidradar.network.ImageOfTheDayJsonAdapter",
                     "com.tarek.asteroidradar.network.DataTransferObjectsKt",
                     // Generated code patterns. `**` matches any chars including dots so the
                     // pattern catches cross-package classes; plain `*` only matches within a
@@ -244,12 +239,6 @@ dependencies {
 
     implementation(libs.androidx.room.runtime)
     ksp(libs.androidx.room.compiler)
-
-    // Generates `ImageOfTheDayJsonAdapter` from `@JsonClass(generateAdapter = true)`.
-    // Codegen avoids the reflection path (which R8 strips kotlin-reflect from in
-    // release builds), so MoshiConverterFactory finds the generated adapter at
-    // runtime via Class.forName instead of reflecting over the data class.
-    ksp(libs.moshi.kotlin.codegen)
 
     implementation(libs.androidx.work.runtime.ktx)
     // androidx-hilt:hilt-work is a separate artifact group from the dagger-hilt

--- a/app/src/main/java/com/tarek/asteroidradar/domain/PictureOfDay.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/domain/PictureOfDay.kt
@@ -28,10 +28,7 @@
  */
 package com.tarek.asteroidradar.domain
 
-import com.squareup.moshi.Json
-
 data class PictureOfDay(
-    @Json(name = "media_type")
     val mediaType: String,
     val title: String,
     val url: String,

--- a/app/src/main/java/com/tarek/asteroidradar/network/DataTransferObjects.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/network/DataTransferObjects.kt
@@ -28,15 +28,15 @@
  */
 package com.tarek.asteroidradar.network
 
-import com.squareup.moshi.Json
-import com.squareup.moshi.JsonClass
 import com.tarek.asteroidradar.database.DatabaseAsteroid
 import com.tarek.asteroidradar.domain.Asteroid
 import com.tarek.asteroidradar.domain.PictureOfDay
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
-@JsonClass(generateAdapter = true)
+@Serializable
 data class ImageOfTheDay(
-    @Json(name = "media_type")
+    @SerialName("media_type")
     val mediaType: String,
     val title: String,
     val url: String,

--- a/app/src/main/java/com/tarek/asteroidradar/network/service.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/network/service.kt
@@ -28,11 +28,11 @@
  */
 package com.tarek.asteroidradar.network
 
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import com.tarek.asteroidradar.util.Constants
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
 import retrofit2.Retrofit
-import retrofit2.converter.moshi.MoshiConverterFactory
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Query
@@ -42,7 +42,7 @@ import retrofit2.http.Query
  *
  * `getAsteroids` returns the raw JSON body as `String` (the `/neo/rest/v1/feed`
  * payload is parsed manually in `parseAsteroidsJsonResult` because of its
- * nested-by-date shape). `getImageOfDay` returns a Moshi-decoded
+ * nested-by-date shape). `getImageOfDay` returns a kotlinx-serialization-decoded
  * [ImageOfTheDay].
  */
 interface AsteroidService {
@@ -57,25 +57,23 @@ interface AsteroidService {
     ): ImageOfTheDay
 }
 
-private val moshi =
-    Moshi
-        .Builder()
-        .add(KotlinJsonAdapterFactory())
-        .build()
+// `ignoreUnknownKeys = true` lets the APOD response evolve (NASA frequently
+// adds fields like `copyright`, `date`, `explanation`, `hdurl`, `service_version`)
+// without us recompiling — only the three fields we annotate on `ImageOfTheDay`
+// are required to be present.
+private val json = Json { ignoreUnknownKeys = true }
 
-// Register Scalars before Moshi: Retrofit walks factories in order; Scalars
-// matches `String` returns and yields the raw response body, while Moshi
-// handles everything else (`ImageOfTheDay`). The earlier custom
-// `HandleScalarAndJsonConverterFactory` dispatched by per-method annotation
-// (`@ScalarResponse` / `@JsonResponse`) but had a non-local-return bug and
-// was fragile under R8 minification — issue #113 replaced it with this
-// stock Retrofit pattern.
+// Register Scalars before the kotlinx-serialization converter: Retrofit walks
+// factories in order; Scalars matches `String` returns and yields the raw
+// response body, while kotlinx-serialization handles `@Serializable` DTOs
+// (`ImageOfTheDay`). Phase 11 replaced Moshi here — single serialization
+// library across nav routes (Phase 9c) and HTTP, fully reflection-free.
 private val retrofit =
     Retrofit
         .Builder()
         .baseUrl(Constants.BASE_URL)
         .addConverterFactory(ScalarsConverterFactory.create())
-        .addConverterFactory(MoshiConverterFactory.create(moshi))
+        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
         .build()
 
 object AsteroidApi {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,7 +36,6 @@ coil = "2.7.0"
 # Kotlin bump. `enableAggregatingTask = true` (the default since 2.45) is kept
 # explicit in the convention plugin.
 hilt = "2.52"
-moshi = "1.15.2"
 retrofit = "3.0.0"
 timber = "5.0.1"
 
@@ -101,16 +100,11 @@ kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutine
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 
-moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
-moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "moshi" }
-# Compile-time `@JsonClass(generateAdapter = true)` adapter generator (KSP).
-# Without this processor the annotation is a no-op, Moshi falls back to
-# reflection, and R8 strips kotlin-reflect aggressively → release builds
-# fail with "Unable to create converter for class …" (issue #113).
-moshi-kotlin-codegen = { module = "com.squareup.moshi:moshi-kotlin-codegen", version.ref = "moshi" }
-
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
-retrofit-converter-moshi = { module = "com.squareup.retrofit2:converter-moshi", version.ref = "retrofit" }
+# Phase 11 replaced Moshi with kotlinx-serialization. Retrofit 3 ships an
+# official converter that calls `Json.encodeToString` / `decodeFromString`
+# under the hood — no codegen processor or reflection required.
+retrofit-converter-kotlinx-serialization = { module = "com.squareup.retrofit2:converter-kotlinx-serialization", version.ref = "retrofit" }
 retrofit-converter-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
@@ -159,14 +153,14 @@ compose = [
     "androidx-navigation-compose",
     "coil-compose",
 ]
-# Retrofit + Moshi networking stack — both response converters; the Jake
-# Wharton kotlin-coroutines-adapter was dropped in Phase 10 (Retrofit 3 has
-# native suspend support, no longer using Deferred returns).
+# Retrofit networking stack — Scalars converter for the raw-string NeoWs
+# feed and the kotlinx-serialization converter for `@Serializable` DTOs.
+# Phase 10 dropped the Jake Wharton coroutines adapter (Retrofit 3 has
+# native suspend support); Phase 11 replaced Moshi with kotlinx-serialization
+# (single serialization library, fully reflection-free, no codegen processor).
 networking = [
-    "moshi",
-    "moshi-kotlin",
     "retrofit",
-    "retrofit-converter-moshi",
+    "retrofit-converter-kotlinx-serialization",
     "retrofit-converter-scalars",
 ]
 # Instrumented-test libs that go on the androidTest classpath together.


### PR DESCRIPTION
## Summary

Single serialization library across the codebase: nav routes (Phase 9c) and HTTP body deserialization both now go through `kotlinx.serialization`. **No runtime reflection, no codegen processor, no `kotlin-reflect` transitive dependency to preserve under R8.** The Phase 10 `buildHealth` gate held; Phase 11 reaps the dependency Phase 9c already paid for.

### Code

- `network/DataTransferObjects.kt` — `ImageOfTheDay` flips from `@JsonClass(generateAdapter = true)` + `@Json(name = "media_type")` to `@Serializable` + `@SerialName("media_type")`.
- `network/service.kt` — drop `Moshi.Builder() + KotlinJsonAdapterFactory + MoshiConverterFactory`; replace with `Json { ignoreUnknownKeys = true }.asConverterFactory("application/json".toMediaType())` from the official `retrofit2-converter-kotlinx-serialization`. Builder order unchanged (Scalars first, kotlinx second).
- `domain/PictureOfDay.kt` — drop the dead `@Json` on the domain model (the conversion from network DTO to domain happens in `asDomainModel()`; the domain model doesn't need a serialization annotation).

### Catalog cleanup

- **Drop**: `moshi`, `moshi-kotlin`, `moshi-kotlin-codegen`, `retrofit-converter-moshi`, plus the `moshi` version pin.
- **Add**: `retrofit-converter-kotlinx-serialization` (`com.squareup.retrofit2:converter-kotlinx-serialization`, version tracks Retrofit).
- **Update**: `[bundles] networking` swap Moshi for kotlinx-serialization. App build script drops `ksp(libs.moshi.kotlin.codegen)`.

### Kover

- Drop `ImageOfTheDayJsonAdapter` exclude (no longer generated). The `ImageOfTheDay$$serializer` companion is already covered by Phase 10's `**$$serializer` glob.

### Version

Bumps `versionPatch` to 2 (`v3.0.2-INTERNAL`). Internal refactor only; no user-visible change.

## Test plan

- [x] `./gradlew spotlessCheck detekt lintRelease assembleDebug assembleRelease test koverVerify buildHealth` — all green.
- [x] `./gradlew :app:connectedDebugAndroidTest` — 8/8 on Pixel 7 Pro AVD.
- [x] Release-APK on-device smoke (fresh install): APOD image renders, asteroid list populates with 7 entries, no converter / serialization errors in logcat.
- [x] `unzip -p classes*.dex | strings | grep "^kotlin/reflect/"` returns empty — fully reflection-free at runtime.

## Out of scope

- Migrating `parseAsteroidsJsonResult` (the `org.json.JSONObject`-based parser of the nested-by-date NeoWs feed) to kotlinx.serialization. Doable with a `JsonTransformingSerializer`; small surface, captured in [issue #115](https://github.com/Tarek-Bohdima/AsteroidRadar/issues/115#out-of-scope) as Phase 11b.

Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)