### PR TITLE
refactor: inject AsteroidService via Hilt — kill AsteroidApi service-locator

### DIFF
--- a/app/src/main/java/com/tarek/asteroidradar/di/NetworkModule.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/di/NetworkModule.kt
@@ -28,48 +28,47 @@
  */
 package com.tarek.asteroidradar.di
 
-import android.content.Context
-import androidx.room.Room
-import com.tarek.asteroidradar.database.AsteroidDao
-import com.tarek.asteroidradar.database.AsteroidDatabase
-import com.tarek.asteroidradar.database.MIGRATION_1_2
-import com.tarek.asteroidradar.database.PictureOfDayDao
 import com.tarek.asteroidradar.network.AsteroidService
-import com.tarek.asteroidradar.repository.AsteroidRepository
+import com.tarek.asteroidradar.util.Constants
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import retrofit2.converter.scalars.ScalarsConverterFactory
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object DatabaseModule {
+object NetworkModule {
+    // `ignoreUnknownKeys = true` lets the APOD response evolve (NASA frequently
+    // adds fields like `copyright`, `date`, `explanation`, `hdurl`, `service_version`)
+    // without us recompiling — only the three fields annotated on `ImageOfTheDay`
+    // are required to be present.
     @Provides
     @Singleton
-    fun provideAsteroidDatabase(
-        @ApplicationContext context: Context,
-    ): AsteroidDatabase =
-        Room
-            .databaseBuilder(
-                context,
-                AsteroidDatabase::class.java,
-                "asteroids",
-            ).addMigrations(MIGRATION_1_2)
+    fun provideJson(): Json = Json { ignoreUnknownKeys = true }
+
+    // Builder order matters: Scalars first matches `String` returns and yields
+    // the raw response body (for `getAsteroids`, where the parser walks the
+    // nested-by-date payload manually); kotlinx-serialization second handles
+    // `@Serializable` DTOs (`ImageOfTheDay`). Phase 11 made this the only
+    // serialization library across both nav routes and HTTP — fully
+    // reflection-free at runtime.
+    @Provides
+    @Singleton
+    fun provideRetrofit(json: Json): Retrofit =
+        Retrofit
+            .Builder()
+            .baseUrl(Constants.BASE_URL)
+            .addConverterFactory(ScalarsConverterFactory.create())
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()
 
     @Provides
-    fun provideAsteroidDao(database: AsteroidDatabase): AsteroidDao = database.asteroidDao
-
-    @Provides
-    fun providePictureOfDayDao(database: AsteroidDatabase): PictureOfDayDao = database.pictureOfDayDao
-
-    @Provides
     @Singleton
-    fun provideAsteroidRepository(
-        asteroidDao: AsteroidDao,
-        pictureOfDayDao: PictureOfDayDao,
-        asteroidService: AsteroidService,
-    ): AsteroidRepository = AsteroidRepository(asteroidDao, pictureOfDayDao, asteroidService)
+    fun provideAsteroidService(retrofit: Retrofit): AsteroidService = retrofit.create(AsteroidService::class.java)
 }

--- a/app/src/main/java/com/tarek/asteroidradar/network/AsteroidService.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/network/AsteroidService.kt
@@ -29,11 +29,6 @@
 package com.tarek.asteroidradar.network
 
 import com.tarek.asteroidradar.util.Constants
-import kotlinx.serialization.json.Json
-import okhttp3.MediaType.Companion.toMediaType
-import retrofit2.Retrofit
-import retrofit2.converter.kotlinx.serialization.asConverterFactory
-import retrofit2.converter.scalars.ScalarsConverterFactory
 import retrofit2.http.GET
 import retrofit2.http.Query
 
@@ -44,6 +39,10 @@ import retrofit2.http.Query
  * payload is parsed manually in `parseAsteroidsJsonResult` because of its
  * nested-by-date shape). `getImageOfDay` returns a kotlinx-serialization-decoded
  * [ImageOfTheDay].
+ *
+ * Construction (Retrofit instance, JSON config, converter ordering) lives in
+ * `di/NetworkModule.kt`; the service is provided as a `@Singleton` Hilt binding
+ * and injected wherever it is consumed.
  */
 interface AsteroidService {
     @GET("neo/rest/v1/feed")
@@ -55,27 +54,4 @@ interface AsteroidService {
     suspend fun getImageOfDay(
         @Query(Constants.PARAMETER_API_KEY) key: String,
     ): ImageOfTheDay
-}
-
-// `ignoreUnknownKeys = true` lets the APOD response evolve (NASA frequently
-// adds fields like `copyright`, `date`, `explanation`, `hdurl`, `service_version`)
-// without us recompiling — only the three fields we annotate on `ImageOfTheDay`
-// are required to be present.
-private val json = Json { ignoreUnknownKeys = true }
-
-// Register Scalars before the kotlinx-serialization converter: Retrofit walks
-// factories in order; Scalars matches `String` returns and yields the raw
-// response body, while kotlinx-serialization handles `@Serializable` DTOs
-// (`ImageOfTheDay`). Phase 11 replaced Moshi here — single serialization
-// library across nav routes (Phase 9c) and HTTP, fully reflection-free.
-private val retrofit =
-    Retrofit
-        .Builder()
-        .baseUrl(Constants.BASE_URL)
-        .addConverterFactory(ScalarsConverterFactory.create())
-        .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
-        .build()
-
-object AsteroidApi {
-    val retrofitService: AsteroidService by lazy { retrofit.create(AsteroidService::class.java) }
 }

--- a/app/src/main/java/com/tarek/asteroidradar/repository/AsteroidRepository.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/repository/AsteroidRepository.kt
@@ -34,7 +34,7 @@ import com.tarek.asteroidradar.database.PictureOfDayDao
 import com.tarek.asteroidradar.database.asDomainModel
 import com.tarek.asteroidradar.domain.Asteroid
 import com.tarek.asteroidradar.domain.PictureOfDay
-import com.tarek.asteroidradar.network.AsteroidApi
+import com.tarek.asteroidradar.network.AsteroidService
 import com.tarek.asteroidradar.network.asDatabaseModel
 import com.tarek.asteroidradar.network.parseAsteroidsJsonResult
 import kotlinx.coroutines.Dispatchers
@@ -48,6 +48,7 @@ import java.time.LocalDate
 class AsteroidRepository(
     private val asteroidDao: AsteroidDao,
     private val pictureOfDayDao: PictureOfDayDao,
+    private val asteroidService: AsteroidService,
 ) {
     sealed class AsteroidsFilter {
         data object TODAY : AsteroidsFilter()
@@ -94,7 +95,7 @@ class AsteroidRepository(
         withContext(Dispatchers.IO) {
             try {
                 pictureOfDayDao.insertPictureOfDay(
-                    AsteroidApi.retrofitService.getImageOfDay(API_KEY).asDatabaseModel(),
+                    asteroidService.getImageOfDay(API_KEY).asDatabaseModel(),
                 )
             } catch (e: Exception) {
                 Timber.d("AsteroidRepository: refreshPictureOfDay() failed %s", e.message)
@@ -105,8 +106,7 @@ class AsteroidRepository(
     suspend fun refreshAsteroids() {
         withContext(Dispatchers.IO) {
             try {
-                val asteroidsJson =
-                    AsteroidApi.retrofitService.getAsteroids(API_KEY)
+                val asteroidsJson = asteroidService.getAsteroids(API_KEY)
                 asteroidDao.insertAll(
                     *parseAsteroidsJsonResult(JSONObject(asteroidsJson))
                         .asDatabaseModel(),

--- a/app/src/test/java/com/tarek/asteroidradar/repository/AsteroidRepositoryTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/repository/AsteroidRepositoryTest.kt
@@ -35,25 +35,36 @@ import com.tarek.asteroidradar.database.DatabasePictureOfDay
 import com.tarek.asteroidradar.database.PictureOfDayDao
 import com.tarek.asteroidradar.database.asDomainModel
 import com.tarek.asteroidradar.domain.PictureOfDay
+import com.tarek.asteroidradar.network.AsteroidService
+import com.tarek.asteroidradar.network.ImageOfTheDay
 import com.tarek.asteroidradar.repository.AsteroidRepository.AsteroidsFilter
+import com.tarek.asteroidradar.util.Constants
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Test
+import java.io.IOException
+import java.text.SimpleDateFormat
 import java.time.LocalDate
+import java.util.Calendar
+import java.util.Locale
 
 class AsteroidRepositoryTest {
     private lateinit var dao: FakeAsteroidDao
     private lateinit var pictureOfDayDao: FakePictureOfDayDao
+    private lateinit var service: FakeAsteroidService
     private lateinit var repository: AsteroidRepository
 
     @Before
     fun setUp() {
         dao = FakeAsteroidDao()
         pictureOfDayDao = FakePictureOfDayDao()
-        repository = AsteroidRepository(dao, pictureOfDayDao)
+        service = FakeAsteroidService()
+        repository = AsteroidRepository(dao, pictureOfDayDao, service)
     }
 
     @Test
@@ -126,6 +137,65 @@ class AsteroidRepositoryTest {
             assertThat(result).isNull()
         }
 
+    @Test
+    fun `refreshAsteroids inserts parsed entities into the DAO`() =
+        runTest {
+            val today = nextSevenDaysFormattedDates().first()
+            service.asteroidsResult = { feedWithSingleAsteroidOn(today) }
+
+            repository.refreshAsteroids()
+
+            assertThat(dao.insertAllCalls).hasSize(1)
+            val inserted = dao.insertAllCalls.single()
+            assertThat(inserted).hasSize(1)
+            with(inserted.single()) {
+                assertThat(id).isEqualTo(SAMPLE_ID)
+                assertThat(closeApproachDate).isEqualTo(today)
+                assertThat(isPotentiallyHazardous).isTrue()
+            }
+        }
+
+    @Test
+    fun `refreshAsteroids swallows network exceptions and leaves the DAO untouched`() =
+        runTest {
+            service.asteroidsResult = { throw IOException("simulated network failure") }
+
+            repository.refreshAsteroids()
+
+            assertThat(dao.insertAllCalls).isEmpty()
+        }
+
+    @Test
+    fun `refreshPictureOfDay persists the converted entity into the DAO`() =
+        runTest {
+            service.imageOfDayResult = {
+                ImageOfTheDay(
+                    mediaType = "image",
+                    title = "APOD title",
+                    url = "https://example.invalid/apod.jpg",
+                )
+            }
+
+            repository.refreshPictureOfDay()
+
+            assertThat(pictureOfDayDao.insertCalls).hasSize(1)
+            with(pictureOfDayDao.insertCalls.single()) {
+                assertThat(mediaType).isEqualTo("image")
+                assertThat(title).isEqualTo("APOD title")
+                assertThat(url).isEqualTo("https://example.invalid/apod.jpg")
+            }
+        }
+
+    @Test
+    fun `refreshPictureOfDay swallows network exceptions and leaves the DAO untouched`() =
+        runTest {
+            service.imageOfDayResult = { throw IOException("simulated network failure") }
+
+            repository.refreshPictureOfDay()
+
+            assertThat(pictureOfDayDao.insertCalls).isEmpty()
+        }
+
     private fun asteroidEntity(
         id: Long,
         date: String = LocalDate.now().toString(),
@@ -140,6 +210,63 @@ class AsteroidRepositoryTest {
             distanceFromEarth = 0.025,
             isPotentiallyHazardous = id % 2L == 0L,
         )
+
+    // Builds the same 8-date NeoWs feed shape `parseAsteroidsJsonResult` expects,
+    // with one populated asteroid on `today` and empty arrays for the remaining
+    // dates. Mirrors the fixture used in ParseAsteroidsJsonResultTest.
+    private fun feedWithSingleAsteroidOn(today: String): String {
+        val dates = nextSevenDaysFormattedDates()
+        val nearEarthObjects =
+            JSONObject().apply {
+                dates.forEach { date ->
+                    if (date == today) {
+                        put(date, JSONArray().put(populatedAsteroidJson(date)))
+                    } else {
+                        put(date, JSONArray())
+                    }
+                }
+            }
+        return JSONObject().put("near_earth_objects", nearEarthObjects).toString()
+    }
+
+    private fun populatedAsteroidJson(date: String): JSONObject =
+        JSONObject().apply {
+            put("id", SAMPLE_ID)
+            put("name", "(2024 AB1)")
+            put("absolute_magnitude_h", 19.5)
+            put(
+                "estimated_diameter",
+                JSONObject().put(
+                    "kilometers",
+                    JSONObject().put("estimated_diameter_max", 0.42),
+                ),
+            )
+            put(
+                "close_approach_data",
+                JSONArray().put(
+                    JSONObject().apply {
+                        put("close_approach_date", date)
+                        put("relative_velocity", JSONObject().put("kilometers_per_second", 11.7))
+                        put("miss_distance", JSONObject().put("astronomical", 0.025))
+                    },
+                ),
+            )
+            put("is_potentially_hazardous_asteroid", true)
+        }
+
+    private fun nextSevenDaysFormattedDates(): List<String> {
+        val cal = Calendar.getInstance()
+        val fmt = SimpleDateFormat(Constants.API_QUERY_DATE_FORMAT, Locale.getDefault())
+        return (0..Constants.DEFAULT_END_DATE_DAYS).map {
+            val s = fmt.format(cal.time)
+            cal.add(Calendar.DAY_OF_YEAR, 1)
+            s
+        }
+    }
+
+    private companion object {
+        const val SAMPLE_ID = 54218396L
+    }
 }
 
 private class FakeAsteroidDao : AsteroidDao {
@@ -151,6 +278,8 @@ private class FakeAsteroidDao : AsteroidDao {
         private set
     var getWeeklyCalledWith: Pair<String, String>? = null
         private set
+
+    val insertAllCalls = mutableListOf<List<DatabaseAsteroid>>()
 
     override fun getAsteroids(): Flow<List<DatabaseAsteroid>> = allFlow
 
@@ -168,7 +297,7 @@ private class FakeAsteroidDao : AsteroidDao {
     }
 
     override fun insertAll(vararg asteroids: DatabaseAsteroid) {
-        error("not used in this test")
+        insertAllCalls += asteroids.toList()
     }
 
     override suspend fun deletePreviousAsteroid(today: String) {
@@ -178,10 +307,20 @@ private class FakeAsteroidDao : AsteroidDao {
 
 private class FakePictureOfDayDao : PictureOfDayDao {
     val flow = MutableStateFlow<DatabasePictureOfDay?>(null)
+    val insertCalls = mutableListOf<DatabasePictureOfDay>()
 
     override fun getPictureOfDay(): Flow<DatabasePictureOfDay?> = flow
 
     override suspend fun insertPictureOfDay(pictureOfDay: DatabasePictureOfDay) {
-        error("not used in this test")
+        insertCalls += pictureOfDay
     }
+}
+
+private class FakeAsteroidService : AsteroidService {
+    var asteroidsResult: () -> String = { error("getAsteroids not stubbed") }
+    var imageOfDayResult: () -> ImageOfTheDay = { error("getImageOfDay not stubbed") }
+
+    override suspend fun getAsteroids(key: String): String = asteroidsResult()
+
+    override suspend fun getImageOfDay(key: String): ImageOfTheDay = imageOfDayResult()
 }


### PR DESCRIPTION
Fixes #120. Pure refactor — no user-visible change.

## Summary

- The repository previously reached into a global `AsteroidApi` singleton for the NeoWs feed and APOD endpoints (Service Locator anti-pattern). Hilt provides everything else in this graph; pulling the network layer into the same convention closes the gap and unlocks unit coverage on the refresh paths.
- New `di/NetworkModule.kt` provides `Json`, `Retrofit`, and `AsteroidService` as `@Singleton` bindings. Builder order preserved (Scalars first for the `String`-returning `getAsteroids`, kotlinx-serialization second for the `@Serializable` `ImageOfTheDay`).
- `network/service.kt` → renamed to `AsteroidService.kt` (detekt `MatchingDeclarationName` once it became a single-declaration file). `AsteroidApi` object + private retrofit/json top-levels are removed entirely.
- `AsteroidRepository` gains a constructor-injected `AsteroidService` parameter; `DatabaseModule.provideAsteroidRepository` threads it through.
- `AsteroidRepositoryTest` gains `FakeAsteroidService` + 4 new tests on the refresh paths (happy + network-failure for both endpoints). The fake DAOs now capture insert calls instead of erroring.

## Acceptance criteria coverage

The G/W/T criteria on issue #120 map to these tests:

- `AsteroidRepositoryTest` → `refreshAsteroids inserts parsed entities into the DAO`, `refreshAsteroids swallows network exceptions and leaves the DAO untouched`, `refreshPictureOfDay persists the converted entity into the DAO`, `refreshPictureOfDay swallows network exceptions and leaves the DAO untouched`.
- The "no observable change" criterion (asteroid list + APOD + filters + detail navigation + offline behaviour preserved) is regression coverage from the existing JVM + instrumented suites + manual smoke. No new tests required.
- The "zero `AsteroidApi` references in production code" criterion is a static check. After this PR, `grep -r AsteroidApi app/src/main` returns zero hits.

## Test plan

- [x] `./gradlew clean spotlessCheck detekt :app:lintRelease :app:testDebugUnitTest :app:assembleDebug`
- [x] `./gradlew :app:koverVerify` (60% INSTRUCTION floor)
- [x] `./gradlew :app:connectedDebugAndroidTest` — 11/11 passed on Pixel_7_Pro AVD (API 33), 6.7s
- [x] **Manual smoke** on Pixel_7_Pro AVD (API 33). Sequence: clean install → fresh launch on Wi-Fi → DB inspection → Wi-Fi off → force-stop → cold relaunch. Findings (full screenshots in the PR comment thread):
    - Fresh online launch — asteroid list rendered (37 rows, dates / hazard icons correct); APOD area showed the placeholder briefly, then transitioned to Coil's `.error(R.drawable.ic_broken_image)` drawable. SQLite dump confirmed the integrated graph is wired correctly: the `picture_of_day` row was written with `id=0`, `mediaType=video`, `title="Supernova in a Sideways Spiral"`, `url=https://apod.nasa.gov/apod/image/2605/sn_2025kid_low.mp4`. Today's APOD is a `.mp4` video — Coil can't render videos; this is pre-existing app behavior on video-days, identical to v3.0.2.
    - Wi-Fi disabled + force-stop + cold relaunch — same screen renders from cache (asteroid list + cached APOD URL). No network call required, no crash, no broken state. Confirms cache-first behaviour and the Hilt-rewired graph is end-to-end functional offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

