### PR TITLE
build: bundle NDK debug symbols into release AAB

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -215,6 +215,14 @@ android {
             )
             buildConfigField("String", "NASA_API_KEY", "\"${env("NASA_API_KEY")}\"")
             signingConfig = signingConfigs.getByName("release")
+            // SYMBOL_TABLE bundles function names from transitive Compose / AndroidX
+            // .so libs into BUNDLE-METADATA/com.android.tools.build.debugsymbols/,
+            // silencing Play Console's "no debug symbols" warning. FULL would also
+            // include source-line info but bloats the AAB 5–20 MB for libraries we
+            // don't own; symbol tables alone make native-frame crashes readable.
+            ndk {
+                debugSymbolLevel = "SYMBOL_TABLE"
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds `ndk { debugSymbolLevel = "SYMBOL_TABLE" }` to `buildTypes.release` in `app/build.gradle.kts` so AGP bundles function-name symbol tables from transitive Compose / AndroidX `.so` libs into `BUNDLE-METADATA/com.android.tools.build.debugsymbols/`.
- Silences Play Console's "you've not uploaded debug symbols" warning emitted on the v3.0.0-INTERNAL upload, and makes native-frame crash reports readable (function names alongside hex offsets).
- Picked `SYMBOL_TABLE` over `FULL` — function names are sufficient for libraries we don't own the source of, and `FULL` would bloat the AAB 5–20 MB.

Build-only change. No app behaviour, no version bump.

## Test plan
- [x] CI build/lint/tests green on this PR.
- [ ] On the next tag's release workflow, `app-release.aab` contains entries under `BUNDLE-METADATA/com.android.tools.build.debugsymbols/` (verify with `unzip -l`).
- [ ] Upload that AAB to Play Console — the "no debug symbols" warning is gone.

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)