### PR TITLE
feat: render APOD video days via Coil VideoFrameDecoder + video-card fallback

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,7 +44,7 @@ plugins {
 // .github/workflows/release.yml greps these names, so don't rename them.
 val versionMajor = 3
 val versionMinor = 0
-val versionPatch = 3
+val versionPatch = 4
 val versionClassifier = "INTERNAL"
 
 // versionCode formula uses minSdk as a high digit so a future minSdk bump
@@ -297,4 +297,6 @@ dependencies {
     // androidx.compose.* dependencies.
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    // Only Espresso surface still wired — MainScreenTest's ACTION_VIEW assertion.
+    androidTestImplementation(libs.androidx.test.espresso.intents)
 }

--- a/app/src/androidTest/java/com/tarek/asteroidradar/ui/main/MainScreenTest.kt
+++ b/app/src/androidTest/java/com/tarek/asteroidradar/ui/main/MainScreenTest.kt
@@ -1,0 +1,162 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.ui.main
+
+import android.app.Activity
+import android.app.Instrumentation
+import android.content.Intent
+import android.net.Uri
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.intent.Intents
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasAction
+import androidx.test.espresso.intent.matcher.IntentMatchers.hasData
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.tarek.asteroidradar.R
+import com.tarek.asteroidradar.domain.PictureOfDay
+import org.hamcrest.Matchers.allOf
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class MainScreenTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val imageDayPicture =
+        PictureOfDay(
+            mediaType = "image",
+            title = "Quiet Sun",
+            url = "https://apod.nasa.gov/apod/image/2605/sun.jpg",
+        )
+
+    // file:// URL guarantees Coil hits its error path synchronously (no network
+    // round-trip), so the fallback slot composes deterministically inside the
+    // test's waitUntil window.
+    private val videoDayPicture =
+        PictureOfDay(
+            mediaType = "video",
+            title = "Supernova in a Sideways Spiral",
+            url = "file:///does/not/exist.mp4",
+        )
+
+    @Before
+    fun setUp() {
+        Intents.init()
+        // Stub every ACTION_VIEW so videoDayApodTapOpensBrowserIntent doesn't
+        // actually launch a browser activity inside the test process.
+        Intents
+            .intending(hasAction(Intent.ACTION_VIEW))
+            .respondWith(Instrumentation.ActivityResult(Activity.RESULT_OK, null))
+    }
+
+    @After
+    fun tearDown() {
+        Intents.release()
+    }
+
+    @Test
+    fun imageDayApodRendersImage() {
+        composeTestRule.setContent {
+            ImageOfTheDayHeader(picture = imageDayPicture, onVideoTap = {})
+        }
+
+        // Image-day path keeps the "Image of the Day" caption; video-day path
+        // hides it (the fallback card paints over the same area).
+        val caption = composeTestRule.activity.getString(R.string.image_of_the_day)
+        composeTestRule.onNodeWithText(caption).assertIsDisplayed()
+    }
+
+    @Test
+    fun videoDayApodWithUnreadableUrlShowsVideoCard() {
+        composeTestRule.setContent {
+            ImageOfTheDayHeader(picture = videoDayPicture, onVideoTap = {})
+        }
+
+        val cardLabel =
+            composeTestRule.activity.getString(
+                R.string.video_of_the_day_format,
+                videoDayPicture.title,
+            )
+        composeTestRule.waitUntil(timeoutMillis = LOAD_TIMEOUT_MS) {
+            composeTestRule
+                .onAllNodesWithText(cardLabel)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(cardLabel).assertIsDisplayed()
+    }
+
+    @Test
+    fun videoDayApodTapOpensBrowserIntent() {
+        composeTestRule.setContent {
+            val context = LocalContext.current
+            ImageOfTheDayHeader(
+                picture = videoDayPicture,
+                onVideoTap = { url ->
+                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                },
+            )
+        }
+
+        val cardLabel =
+            composeTestRule.activity.getString(
+                R.string.video_of_the_day_format,
+                videoDayPicture.title,
+            )
+        composeTestRule.waitUntil(timeoutMillis = LOAD_TIMEOUT_MS) {
+            composeTestRule
+                .onAllNodesWithText(cardLabel)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(cardLabel).performClick()
+
+        Intents.intended(
+            allOf(
+                hasAction(Intent.ACTION_VIEW),
+                hasData(Uri.parse(videoDayPicture.url)),
+            ),
+        )
+    }
+
+    private companion object {
+        // Coil's file:// load fails almost instantly; 5s is generous headroom
+        // for slow CI emulators without making test failures sluggish.
+        const val LOAD_TIMEOUT_MS = 5_000L
+    }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,6 +33,19 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
 
+    <!-- Android 11+ package visibility: declares the intent shapes the app
+         resolves on other packages so Intent.resolveActivity() and the
+         system's chooser can find handlers. The APOD video-card fallback
+         (#123) fires Intent.ACTION_VIEW on https URLs (NASA YouTube /
+         Vimeo embeds) — without this, resolveActivity() returns null on
+         API 30+ even when a browser is installed. -->
+    <queries>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="https" />
+        </intent>
+    </queries>
+
     <application
         android:name=".AsteroidRadarApplication"
         android:allowBackup="true"

--- a/app/src/main/java/com/tarek/asteroidradar/AsteroidRadarApplication.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/AsteroidRadarApplication.kt
@@ -36,7 +36,10 @@ import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
+import coil.ImageLoader
+import coil.ImageLoaderFactory
 import com.tarek.asteroidradar.work.RefreshDataWorker
+import dagger.Lazy
 import dagger.hilt.android.HiltAndroidApp
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -48,10 +51,16 @@ import javax.inject.Inject
 @HiltAndroidApp
 class AsteroidRadarApplication :
     Application(),
-    Configuration.Provider {
+    Configuration.Provider,
+    ImageLoaderFactory {
     private val applicationScope = CoroutineScope(Dispatchers.Default)
 
     @Inject lateinit var workerFactory: HiltWorkerFactory
+
+    // Lazy so Coil resolves the loader on first AsyncImage compose, not at
+    // Application.onCreate — keeps cold start untouched. Hilt has populated
+    // the field by the time Coil calls newImageLoader().
+    @Inject lateinit var imageLoader: Lazy<ImageLoader>
 
     // The default WorkManagerInitializer is removed in the manifest so this
     // is read by WorkManager.getInstance() lazily — after Hilt has populated
@@ -62,6 +71,8 @@ class AsteroidRadarApplication :
                 .Builder()
                 .setWorkerFactory(workerFactory)
                 .build()
+
+    override fun newImageLoader(): ImageLoader = imageLoader.get()
 
     override fun onCreate() {
         super.onCreate()

--- a/app/src/main/java/com/tarek/asteroidradar/di/NetworkModule.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/di/NetworkModule.kt
@@ -28,11 +28,15 @@
  */
 package com.tarek.asteroidradar.di
 
+import android.content.Context
+import coil.ImageLoader
+import coil.decode.VideoFrameDecoder
 import com.tarek.asteroidradar.network.AsteroidService
 import com.tarek.asteroidradar.util.Constants
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
@@ -71,4 +75,18 @@ object NetworkModule {
     @Provides
     @Singleton
     fun provideAsteroidService(retrofit: Retrofit): AsteroidService = retrofit.create(AsteroidService::class.java)
+
+    // Issue #123: register VideoFrameDecoder so Coil extracts frame 0 from
+    // direct .mp4/.webm URLs (e.g. NASA's APOD video days). The application
+    // exposes this loader via ImageLoaderFactory, so every AsyncImage call
+    // site picks it up without needing per-call wiring.
+    @Provides
+    @Singleton
+    fun provideImageLoader(
+        @ApplicationContext context: Context,
+    ): ImageLoader =
+        ImageLoader
+            .Builder(context)
+            .components { add(VideoFrameDecoder.Factory()) }
+            .build()
 }

--- a/app/src/main/java/com/tarek/asteroidradar/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/ui/main/MainScreen.kt
@@ -28,8 +28,11 @@
  */
 package com.tarek.asteroidradar.ui.main
 
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -66,10 +69,11 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil.compose.AsyncImage
+import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest
 import com.tarek.asteroidradar.R
 import com.tarek.asteroidradar.domain.Asteroid
+import com.tarek.asteroidradar.domain.PictureOfDay
 import com.tarek.asteroidradar.repository.AsteroidRepository.AsteroidsFilter
 
 private val ApodHeaderHeight = 220.dp
@@ -86,6 +90,7 @@ fun MainScreen(
 ) {
     val asteroids by viewModel.asteroids.collectAsStateWithLifecycle()
     val image by viewModel.imageOfTheDay.collectAsStateWithLifecycle()
+    val context = LocalContext.current
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
@@ -98,7 +103,12 @@ fun MainScreen(
                     .fillMaxSize()
                     .padding(padding),
         ) {
-            ImageOfTheDayHeader(imageUrl = image?.url)
+            ImageOfTheDayHeader(
+                picture = image,
+                onVideoTap = { url ->
+                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                },
+            )
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 items(asteroids, key = { it.id }) { asteroid ->
                     AsteroidRow(asteroid = asteroid, onClick = { onAsteroidClick(asteroid) })
@@ -154,41 +164,98 @@ private fun MainTopBar(onFilterSelect: (AsteroidsFilter) -> Unit) {
     )
 }
 
+// `internal` so MainScreenTest can render this composable without going
+// through the Hilt-injected MainViewModel — same testing seam DetailScreen
+// uses by accepting its data as a parameter.
 @Composable
-private fun ImageOfTheDayHeader(
-    imageUrl: String?,
+internal fun ImageOfTheDayHeader(
+    picture: PictureOfDay?,
+    onVideoTap: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val isVideo = picture?.mediaType == "video"
     Box(
         modifier =
             modifier
                 .fillMaxWidth()
                 .height(ApodHeaderHeight),
     ) {
-        AsyncImage(
+        SubcomposeAsyncImage(
             model =
                 ImageRequest
                     .Builder(context)
-                    .data(imageUrl?.replaceFirst(Regex("^http://"), "https://"))
+                    .data(picture?.url?.replaceFirst(Regex("^http://"), "https://"))
                     .placeholder(R.drawable.placeholder_picture_of_day)
-                    .error(R.drawable.ic_broken_image)
                     .crossfade(true)
                     .build(),
             contentDescription = stringResource(R.string.image_of_the_day),
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize(),
+            error = {
+                // VideoFrameDecoder handles direct .mp4/.webm — when it can't
+                // (YouTube/Vimeo embeds), fall back to a tap-through card
+                // instead of a broken-image icon.
+                if (picture?.mediaType == "video") {
+                    VideoFallbackCard(
+                        title = picture.title,
+                        onClick = { onVideoTap(picture.url) },
+                    )
+                } else {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_broken_image),
+                        contentDescription = null,
+                        tint = Color.Unspecified,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                }
+            },
+        )
+        // Caption stays visible on image-days; on video-days the card paints
+        // over it via the error slot's fillMaxSize, so no double-label.
+        if (!isVideo) {
+            Text(
+                text = stringResource(R.string.image_of_the_day),
+                color = colorResource(R.color.default_text_color),
+                style = MaterialTheme.typography.titleLarge,
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomStart)
+                        .fillMaxWidth()
+                        .background(colorResource(R.color.image_of_day_caption_scrim))
+                        .padding(16.dp),
+            )
+        }
+    }
+}
+
+@Composable
+internal fun VideoFallbackCard(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(colorResource(R.color.image_of_day_caption_scrim))
+                .clickable(onClick = onClick)
+                .padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_videocam),
+            contentDescription = stringResource(R.string.video_of_the_day_open),
+            tint = colorResource(R.color.default_text_color),
+            modifier = Modifier.height(48.dp),
         )
         Text(
-            text = stringResource(R.string.image_of_the_day),
+            text = stringResource(R.string.video_of_the_day_format, title),
             color = colorResource(R.color.default_text_color),
-            style = MaterialTheme.typography.titleLarge,
-            modifier =
-                Modifier
-                    .align(Alignment.BottomStart)
-                    .fillMaxWidth()
-                    .background(colorResource(R.color.image_of_day_caption_scrim))
-                    .padding(16.dp),
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier.padding(top = 8.dp),
         )
     }
 }

--- a/app/src/main/res/drawable/ic_videocam.xml
+++ b/app/src/main/res/drawable/ic_videocam.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17,10.5V7c0,-0.55 -0.45,-1 -1,-1H4c-0.55,0 -1,0.45 -1,1v10c0,0.55 0.45,1 1,1h12c0.55,0 1,-0.45 1,-1v-3.5l4,4v-11l-4,4z" />
+</vector>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -38,6 +38,8 @@
     <string name="relative_velocity_title">Viteza relativă</string>
     <string name="distance_from_earth_title">Distanța față de pământ</string>
     <string name="image_of_the_day">Imaginea zilei</string>
+    <string name="video_of_the_day_format">Videoclipul zilei — %1$s</string>
+    <string name="video_of_the_day_open">Deschide videoclipul în browser</string>
     <string name="astronomical_unit_explanation">Unitatea astronomică (au) este o unitate de lungime, aproximativ distanța de la Pământ la Soare și egală cu aproximativ 150 de milioane de kilometri (93 de milioane de mile)</string>
     <string name="astronomical_unit_explanation_button">Definiția unității astronomice</string>
     <string name="potentially_hazardous_asteroid_image">Imagine cu asteroid potențial periculoasă</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -42,6 +42,8 @@
     <string name="km_unit_format" translatable="false">%f km</string>
     <string name="km_s_unit_format" translatable="false">%f km/s</string>
     <string name="image_of_the_day">Image of the Day</string>
+    <string name="video_of_the_day_format">Video of the Day — %1$s</string>
+    <string name="video_of_the_day_open">Open video in browser</string>
     <string name="astronomical_unit_explanation">The astronomical unit (au) is a unit of length, roughly the distance from Earth to the Sun and equal to about 150 million kilometres (93 million miles)</string>
     <string name="astronomical_unit_explanation_button">Astronomical unit definition</string>
     <string name="potentially_hazardous_asteroid_image">Potentially hazardous asteroid image</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,10 @@ kotlinxCoroutines = "1.8.1"
 kotlinxSerialization = "1.7.3"
 
 coil = "2.7.0"
+# Espresso — only `intents` is wired (for MainScreenTest's ACTION_VIEW
+# assertion). Phase 10 dropped Espresso-core when the view-system tests
+# went away, so the version pin is scoped to the intents artifact only.
+androidxTestEspresso = "3.7.0"
 # Hilt 2.51+ supports Kotlin 2.x via KSP, which is why DI lands after Phase 4's
 # Kotlin bump. `enableAggregatingTask = true` (the default since 2.45) is kept
 # explicit in the convention plugin.
@@ -108,12 +112,23 @@ retrofit-converter-kotlinx-serialization = { module = "com.squareup.retrofit2:co
 retrofit-converter-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+# coil-video registers a VideoFrameDecoder.Factory that pulls frame 0 out
+# of any direct .mp4/.webm URL Coil downloads — covers NASA APOD video days
+# (#123). The ImageLoader the app provides via NetworkModule installs the
+# factory app-wide; AsyncImage call sites stay unchanged.
+coil-video = { module = "io.coil-kt:coil-video", version.ref = "coil" }
 detekt-compose-rules = { module = "io.nlopez.compose.rules:detekt", version.ref = "composeRules" }
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 
 androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }
+# espresso-intents is the only Espresso surface still on the classpath —
+# MainScreenTest uses `Intents.intended(...)` to assert the ACTION_VIEW
+# fired by the APOD video-card fallback. Pulls espresso-core transitively;
+# kept off the android-test bundle so other tests don't accidentally lean
+# on Espresso matchers.
+androidx-test-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "androidxTestEspresso" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
@@ -152,6 +167,7 @@ compose = [
     "androidx-lifecycle-runtime-compose",
     "androidx-navigation-compose",
     "coil-compose",
+    "coil-video",
 ]
 # Retrofit networking stack — Scalars converter for the raw-string NeoWs
 # feed and the kotlinx-serialization converter for `@Serializable` DTOs.


### PR DESCRIPTION
## Summary

Adds a video path to the APOD header so weekly video days (NASA publishes `media_type=video` roughly weekly — today, 2026-05-08, is one) no longer surface as a broken-image icon.

Two complementary paths:

1. **`coil-video` decoder.** `VideoFrameDecoder.Factory()` registered on the app-wide `ImageLoader` (provided from `NetworkModule`, exposed to Coil via `AsteroidRadarApplication`'s `ImageLoaderFactory` contract). For direct `.mp4`/`.webm` URLs Coil downloads — the common NASA APOD video shape — frame 0 paints in the existing `AsyncImage` slot with the existing crossfade. No `AsyncImage` call-site changes.

2. **Graceful fallback card.** `ImageOfTheDayHeader` switched to `SubcomposeAsyncImage` so the `error` slot can dispatch on `mediaType`. On a video day where the decoder can't extract a frame (YouTube / Vimeo embeds), a tap-through "Video of the Day — *title*" card replaces the broken-image icon. Tap fires `Intent.ACTION_VIEW` with the URL — the lambda is hoisted to `MainScreen` to keep the composable unit-testable.

Other touches:

- **Manifest `<queries>`** declares `ACTION_VIEW` + `scheme=https` so `Intent.resolveActivity()` finds a browser on Android 11+ package-visibility rules.
- **`ic_videocam.xml`** matches the codebase's existing XML-drawable convention (rejected `material-icons-extended` — ~5 MB AAR cost for one icon).
- **`MainScreenTest`** instrumented tests:
  - `imageDayApodRendersImage`
  - `videoDayApodWithUnreadableUrlShowsVideoCard` (uses a `file://` URL so Coil errors synchronously)
  - `videoDayApodTapOpensBrowserIntent` (Espresso `Intents.intended` on `ACTION_VIEW`)
- `espresso-intents` is the only Espresso surface still wired; kept off the `android-test` bundle so other tests don't lean on Espresso matchers.

Patch bump: **v3.0.3-INTERNAL → v3.0.4-INTERNAL** (UX polish, no new screen/filter/data source).

## Test plan

Local CI checks (all green):
- [x] `./gradlew :app:spotlessKotlinCheck`
- [x] `./gradlew :app:detekt`
- [x] `./gradlew :app:lintRelease`
- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew :app:test`
- [x] `./gradlew :app:compileDebugAndroidTestKotlin`
- [x] `./gradlew buildHealth`

Manual verification (on a device, post-merge):
- [ ] On a still-image APOD day: image renders identically to v3.0.3.
- [ ] On a direct-`.mp4` APOD day (today, 2026-05-08): frame 0 paints with the crossfade; relaunch hits the cache.
- [ ] On a YouTube-embed APOD day (next time it lands): "Video of the Day" card; tap opens the URL in the user's browser/YouTube app.
- [ ] Cold-start offline with yesterday's APOD cached: cached row still paints (no #116 regression).

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)