### PR TITLE
Phase 13a: AGP 9 + Kotlin 2.3 + Hilt 2.59 (drop kapt, align to NIA)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -42,9 +42,9 @@ plugins {
 // Version components — bump these (not versionCode / versionName directly) when
 // cutting a release. Classifier choices: INTERNAL, ALPHA, BETA, RC, RELEASE.
 // .github/workflows/release.yml greps these names, so don't rename them.
-val versionMajor = 3
+val versionMajor = 4
 val versionMinor = 0
-val versionPatch = 4
+val versionPatch = 0
 val versionClassifier = "INTERNAL"
 
 // versionCode formula uses minSdk as a high digit so a future minSdk bump
@@ -255,13 +255,9 @@ dependencies {
     implementation(libs.androidx.hilt.work)
     ksp(libs.androidx.hilt.compiler)
 
-    // Hilt's main compiler runs through kapt — see the convention plugin
-    // comment for the JavaPoet/aggregator-task workaround this preserves.
-    // The dagger-hilt compiler comes from the convention plugin's `ksp(...)`
-    // declaration and is overridden here by the kapt path Hilt prefers when
-    // both are present. Drop both this kapt dep and the kapt plugin once
-    // Hilt + Gradle metadata versions realign.
-    kapt(libs.hilt.compiler)
+    // Hilt's compiler + the kotlin-metadata-jvm pin are wired in the
+    // `asteroidradar.android.hilt` convention plugin's `ksp(...)` block; no
+    // module-side declaration needed.
 
     implementation(libs.timber)
 

--- a/build-logic/convention/src/main/kotlin/asteroidradar.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/asteroidradar.android.application.gradle.kts
@@ -29,27 +29,18 @@ import com.android.build.api.dsl.ApplicationExtension
 // signing, buildTypes) stays in the consuming script.
 //
 // Phase 9c retired Data Binding + `androidx.navigation.safeargs.kotlin`
-// (replaced by Nav-Compose typed routes). The kotlinx-serialization compiler
-// plugin is the new entry — required by the @Serializable Asteroid that
-// Nav-Compose encodes into route arguments.
-//
-// `kotlin-kapt` stays applied even though no @BindingAdapter survives, so
-// that `kapt(libs.hilt.compiler)` in :app routes Hilt's aggregating step
-// through kapt instead of the broken Gradle worker. Hilt 2.52's KSP
-// aggregator (`hiltAggregateDeps*`) hits a NoSuchMethodError on
-// `ClassName.canonicalName()` once kapt isn't there to pin JavaPoet 1.13
-// indirectly: AGP brings JavaPoet 1.10 onto the daemon classloader, Gradle's
-// classloader-resolution race lets 1.10 win, and Hilt's bytecode (compiled
-// against 1.13) blows up. Hilt's switch to Palantir's javapoet fork lands in
-// 2.55, but the 2.55+ classes ship with Kotlin 2.1 metadata that even Gradle
-// 8.13's embedded Kotlin (2.0.21) won't read. Until that toolchain bump is
-// taken as its own scoped step, kapt's presence quietly steers Hilt around
-// the bug — there are no other kapt users left, so this is otherwise a no-op.
+// (replaced by Nav-Compose typed routes). Phase 13a retired `kotlin-kapt` —
+// Hilt 2.59+ uses Palantir's javapoet fork (no JavaPoet 1.10 leak) and its
+// compiler now runs through KSP. The kotlinx-serialization compiler plugin
+// stays — required by the @Serializable Asteroid that Nav-Compose encodes
+// into route arguments.
+// AGP 9.0 has built-in Kotlin support — `org.jetbrains.kotlin.android` is no
+// longer applied (and would error out if it were). The Kotlin compile tasks
+// are still configured via the Kotlin Gradle plugin types, since AGP's built-in
+// support uses the same task classes.
 plugins {
     id("com.android.application")
     id("com.autonomousapps.dependency-analysis")
-    id("org.jetbrains.kotlin.android")
-    id("org.jetbrains.kotlin.kapt")
     id("org.jetbrains.kotlin.plugin.parcelize")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("com.google.devtools.ksp")
@@ -83,12 +74,11 @@ extensions.configure<ApplicationExtension> {
     }
 }
 
-// `kotlinOptions` lives on the Kotlin plugin extension, not the Android one;
-// configure it via the project's `tasks.withType<KotlinCompile>()` API so this
-// works on Kotlin 1.6.x as well as later majors that move toward
-// `compilerOptions {}`. Phase 4's Kotlin bump can swap this out cleanly.
+// JVM target on the Kotlin compile tasks. The legacy `kotlinOptions { }` DSL
+// was promoted from deprecation to error in Kotlin 2.3; configure via the
+// Provider-based `compilerOptions` API instead.
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).configureEach {
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }

--- a/build-logic/convention/src/main/kotlin/asteroidradar.android.hilt.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/asteroidradar.android.hilt.gradle.kts
@@ -20,16 +20,18 @@
  * SOFTWARE.
  */
 
-import dagger.hilt.android.plugin.HiltExtension
 import org.gradle.api.artifacts.VersionCatalogsExtension
 
 // Standalone Hilt convention. Applied alongside `asteroidradar.android.application`
 // in :app today; future feature/library modules can opt into DI by adding this
 // plugin alone (their `*.android.library` convention will bring KSP).
 //
-// KSP is re-declared here even though the application convention already
-// applies it; Gradle's plugin manager dedupes by id, and keeping it here makes
-// this convention work in a module that doesn't bring KSP itself.
+// Phase 13a aligned the Hilt setup with Now in Android: compiler wired through
+// KSP (kapt is gone), and `kotlin-metadata-jvm` is pinned explicitly on the
+// KSP classpath so Hilt's processor reads Kotlin 2.3-emitted bytecode metadata
+// (the bundled metadata library inside Hilt is older). `enableAggregatingTask`
+// stays at its default `true` — Hilt 2.59+ uses Palantir's javapoet fork, so
+// the JavaPoet 1.10 NoSuchMethodError that Phase 9c worked around is gone.
 //
 // Catalog access uses `VersionCatalogsExtension` rather than the
 // `LibrariesForLibs` typed accessor — the latter isn't generated for the
@@ -40,26 +42,11 @@ plugins {
     id("com.google.dagger.hilt.android")
 }
 
-// `enableAggregatingTask` defaults to `true` in Hilt 2.52 — turning it off
-// disables the per-variant `hiltAggregateDeps*` worker, which on this
-// toolchain combo (kapt + DataBinding gone, JavaPoet 1.10 leaking onto the
-// daemon classloader from AGP) NoSuchMethodErrors on `ClassName.canonicalName()`.
-// Aggregation falls back to per-module annotation processing — fine for a
-// single-module app. Re-enable when the Hilt + Gradle metadata versions
-// realign and the JavaPoet leak is resolved.
-configure<HiltExtension> {
-    enableAggregatingTask = false
-}
-
-// Hilt's compiler runs through kapt rather than KSP — see the
-// asteroidradar.android.application convention plugin for the JavaPoet
-// workaround context. KSP-based Hilt aggregation still hits the same
-// NoSuchMethodError. The matching `kapt(libs.hilt.compiler)` declaration
-// lives in :app/build.gradle.kts so the catalog accessor stays type-safe.
-
 private val libs = extensions.getByType(VersionCatalogsExtension::class.java).named("libs")
 
 dependencies {
     "implementation"(libs.findLibrary("hilt-android").get())
+    "ksp"(libs.findLibrary("hilt-compiler").get())
+    "ksp"(libs.findLibrary("kotlin-metadata").get())
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,11 +33,23 @@
 // while per-subproject application happens through the convention plugin
 // (root-only application doesn't reach subprojects whose Android plugin is
 // applied via a precompiled script plugin).
+
+// Force a Kotlin 2.3-compatible `kotlin-metadata-jvm` onto the buildscript
+// classpath so DAGP's `ExplodeJarTask` can read 2.3-emitted bytecode metadata.
+// DAGP 2.18.0 bundles `kotlin-metadata-jvm` 2.1.x; without this constraint it
+// fails with "Provided Metadata instance has version 2.3.0, while maximum
+// supported version is 2.1.0". Same trick the Hilt convention plugin uses for
+// its KSP processor.
+buildscript {
+    dependencies {
+        classpath(libs.kotlin.metadata)
+    }
+}
+
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.detekt) apply false
-    alias(libs.plugins.kotlin.android) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.ksp) apply false

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,9 +10,6 @@
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects
 # org.gradle.parallel=true
-#Wed Mar 13 00:41:28 EET 2024
-android.enableJetifier=true
-android.nonTransitiveRClass=false
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,13 @@
 # Version catalog — single source of truth for plugin / library versions.
-# Phase 1 of docs/IMPROVEMENT_PLAN.md. Versions match the pre-migration baseline
-# exactly; the toolchain bump in Phase 4 will move them in a coordinated PR.
 
 [versions]
-agp = "8.7.3"
-kotlin = "2.0.21"
-# KSP versions track the Kotlin compiler they were built against — must match.
-ksp = "2.0.21-1.0.27"
+agp = "9.0.0"
+kotlin = "2.3.0"
+# KSP version format is `<kotlin>-<ksp-impl>` since KSP2 (>= 2.0) — must match
+# the Kotlin compiler version exactly on the leading segment. Pinned to NIA's
+# 2.3.4 (Kotlin 2.3.0 baseline) rather than 2.3.7, which is the bleeding edge
+# where Hilt's compatibility hasn't fully caught up.
+ksp = "2.3.4"
 androidxNavigation = "2.8.5"
 
 androidxActivity = "1.10.1"
@@ -23,9 +24,10 @@ androidxLifecycle = "2.8.7"
 androidxRoom = "2.8.0"
 androidxWork = "2.10.0"
 
-# Coroutines core + android unified on a single ref now that they're part of
-# the same toolchain bump. Phase 4a goal.
-kotlinxCoroutines = "1.8.1"
+# Coroutines core + android unified on a single ref. Bumped to the
+# Kotlin-2.3-compatible release in Phase 13a alongside the Kotlin / KSP / AGP
+# toolchain bump.
+kotlinxCoroutines = "1.10.2"
 # kotlinx-serialization-json — typed Nav-Compose routes (Phase 9c) encode
 # Asteroid via Json.encodeToString. The Kotlin Serialization Gradle plugin
 # version-tracks the Kotlin pin, so it doesn't need its own ref.
@@ -36,10 +38,13 @@ coil = "2.7.0"
 # assertion). Phase 10 dropped Espresso-core when the view-system tests
 # went away, so the version pin is scoped to the intents artifact only.
 androidxTestEspresso = "3.7.0"
-# Hilt 2.51+ supports Kotlin 2.x via KSP, which is why DI lands after Phase 4's
-# Kotlin bump. `enableAggregatingTask = true` (the default since 2.45) is kept
-# explicit in the convention plugin.
-hilt = "2.52"
+# Hilt 2.59.2 supports Kotlin 2.3 metadata (the bundled `kotlin-metadata-jvm`
+# is overridden via an explicit `ksp(libs.kotlin.metadata)` declaration in the
+# `asteroidradar.android.hilt` convention plugin — same pattern as Now in
+# Android). 2.55+ switched to Palantir's javapoet fork, so the JavaPoet 1.10
+# `NoSuchMethodError` that Phase 9c worked around with `enableAggregatingTask
+# = false` is gone — aggregation runs at its default `true` again.
+hilt = "2.59.2"
 retrofit = "3.0.0"
 timber = "5.0.1"
 
@@ -60,7 +65,7 @@ composeRules = "0.4.22"
 # Tony Robalik's dependency-analysis-gradle-plugin — `./gradlew buildHealth`
 # flags unused / misplaced / superfluous dependencies. Phase 10. Aggregates
 # subproject reports at the root, so it's applied at the root build script.
-dependencyAnalysis = "2.6.1"
+dependencyAnalysis = "2.18.0"
 detekt = "1.23.8"
 # Kover 0.9.x supports Kotlin 2.0+; aligned with the project's Kotlin pin.
 kover = "0.9.2"
@@ -100,6 +105,7 @@ androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "
 
 androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "androidxWork" }
 
+kotlin-metadata = { module = "org.jetbrains.kotlin:kotlin-metadata-jvm", version.ref = "kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
@@ -206,7 +212,6 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 # The Kotlin Compose Compiler ships as a Kotlin plugin since Kotlin 2.0 — its
 # version tracks the Kotlin compiler pin, not a separate Compose Compiler ref.
 kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 # kotlinx-serialization compiler plugin — version-tracks Kotlin. Required for
 # the @Serializable Asteroid that Nav-Compose typed routes encode.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary

Coordinated toolchain bump aligned to [Now in Android](https://github.com/android/nowinandroid). Folds Phase 13c's kapt removal in — the Hilt compiler runs through KSP now, with `kotlin-metadata-jvm` pinned on the KSP classpath so Hilt's processor reads Kotlin 2.3 metadata (the version bundled inside Hilt is older).

| Pin | From | To | Notes |
|---|---|---|---|
| Gradle wrapper | 8.13 | 9.5.0 | Embedded Kotlin 2.3.20 |
| AGP | 8.7.3 | 9.0.0 | Built-in Kotlin support; `kotlin.android` plugin no longer applied |
| Kotlin | 2.0.21 | 2.3.0 | NIA's pin |
| KSP | 2.0.21-1.0.27 | 2.3.4 | KSP2 dropped the `<kotlin>-1.0.<patch>` format |
| Hilt | 2.52 | 2.59.2 | Palantir javapoet fork — JavaPoet 1.10 leak gone |
| kotlinx-coroutines | 1.8.1 | 1.10.2 | Kotlin 2.3-compatible |
| DAGP | 2.6.1 | 2.18.0 | Latest stable; flags 8.7 as upper-bound known-good but works on 9.0 |
| `kotlin-metadata-jvm` | — | 2.3.0 | New library; declared as `ksp(...)` for Hilt and as buildscript classpath for DAGP |

**Drops**: `kotlin-kapt` plugin, `enableAggregatingTask = false` workaround, `org.jetbrains.kotlin.android` plugin, `android.enableJetifier=true`, `android.nonTransitiveRClass=false`.

**Version-of-record**: `v3.0.4-INTERNAL` → `v4.0.0-INTERNAL` (Kotlin major qualifies as MAJOR per `CLAUDE.md`).

## Why scope expanded vs. issue #78

The original 13a scoped to AGP + Kotlin + KSP + coroutines only. While bumping, two walls forced a rescope:

1. **Hilt 2.56.2 caps `kotlin-metadata-jvm` at metadata 2.2.0** — kapt-driven Hilt processing failed on 2.3-emitted bytecode. NIA's pattern (KSP for Hilt + explicit `kotlin-metadata` pin) is the documented fix. That's exactly what Phase 13c was going to do, so 13c folds in.
2. **AGP 9.0 has built-in Kotlin support** — applying `org.jetbrains.kotlin.android` errors out. Plugin removed at root and from the convention plugin.

Net effect: Phase 13a now closes the kapt category; Phase 13b (AndroidX group bump) becomes the only remaining sub-PR for issue #78.

## Test plan

- [x] `./gradlew spotlessCheck`
- [x] `./gradlew detekt`
- [x] `./gradlew lintRelease` (passes; 63 baseline entries are stale — follow-up regen)
- [x] `./gradlew assembleDebug`
- [x] `./gradlew test` (all JVM unit tests pass)
- [x] `./gradlew buildHealth` (DAGP only flags `kotlin-stdlib` `api`→`implementation` nit — follow-up)
- [x] `./gradlew koverVerify` (60% INSTRUCTION floor)
- [x] `./gradlew assembleRelease` (R8 + minify + lintVitalRelease all green — the v3.0.0 lesson validator)
- [ ] Manual device smoke on a Pixel 7 Pro before tagging `v4.0.0-INTERNAL` (per pre-tag protocol from the v3.x retrospective)

## Follow-ups (separate cleanup commits)

- Lint baseline regen — 63 stale entries no longer apply post-bump.
- DAGP nit: `kotlin-stdlib` should be `implementation` not `api` in `:app`.
- Investigate the `Deprecated Gradle features were used` Gradle warning (likely a transitive plugin; identify with `--warning-mode all`).

Refs #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)