### PR TITLE
Phase 13b: AndroidX group bump (lifecycle 2.10 + nav 2.9.8 + room 2.8.4 + work 2.11.2)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,7 +44,7 @@ plugins {
 // .github/workflows/release.yml greps these names, so don't rename them.
 val versionMajor = 4
 val versionMinor = 0
-val versionPatch = 0
+val versionPatch = 1
 val versionClassifier = "INTERNAL"
 
 // versionCode formula uses minSdk as a high digit so a future minSdk bump

--- a/app/src/main/java/com/tarek/asteroidradar/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/ui/main/MainScreen.kt
@@ -67,7 +67,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.SubcomposeAsyncImage
 import coil.request.ImageRequest

--- a/build-logic/convention/src/main/kotlin/asteroidradar.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/asteroidradar.android.application.gradle.kts
@@ -47,11 +47,14 @@ plugins {
 }
 
 extensions.configure<ApplicationExtension> {
-    compileSdk = 35
+    // SDK 36 (Android 16) is the new floor for AndroidX 2.10/2.9 lifecycle and
+    // navigation; bumped alongside the Phase 13b group bump. minSdk stays at
+    // 26 (no breaking-for-users bump per the SemVer table in CLAUDE.md).
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 36
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,21 +8,23 @@ kotlin = "2.3.0"
 # 2.3.4 (Kotlin 2.3.0 baseline) rather than 2.3.7, which is the bleeding edge
 # where Hilt's compatibility hasn't fully caught up.
 ksp = "2.3.4"
-androidxNavigation = "2.8.5"
+androidxNavigation = "2.9.8"
 
-androidxActivity = "1.10.1"
-androidxAppcompat = "1.7.0"
+androidxActivity = "1.13.0"
+androidxAppcompat = "1.7.1"
 # Compose BOM aligns the rest of the androidx.compose.* artifacts (Material 3,
 # UI, tooling). The activity/lifecycle/navigation/hilt-compose deps are
 # published outside the BOM and pin alongside their non-Compose siblings.
+# BOM is intentionally NOT bumped in Phase 13b — Compose surface needs its
+# own validation phase, separate from the AndroidX-core group bump.
 androidxComposeBom = "2025.01.01"
-androidxConstraintlayout = "2.2.0"
+androidxConstraintlayout = "2.2.1"
 # androidx.hilt:* (hilt-work, hilt-compiler) is a separate artifact group from
 # com.google.dagger:hilt-*; KSP-supported since 1.2.0.
-androidxHilt = "1.2.0"
-androidxLifecycle = "2.8.7"
-androidxRoom = "2.8.0"
-androidxWork = "2.10.0"
+androidxHilt = "1.3.0"
+androidxLifecycle = "2.10.0"
+androidxRoom = "2.8.4"
+androidxWork = "2.11.2"
 
 # Coroutines core + android unified on a single ref. Bumped to the
 # Kotlin-2.3-compatible release in Phase 13a alongside the Kotlin / KSP / AGP


### PR DESCRIPTION
## Summary

Last sub-PR for the Phase 13 umbrella (issue #78). Patch bump on `v4.0.0-INTERNAL` — no breaking surface introduced beyond what 13a already shipped.

| Pin | From | To |
|---|---|---|
| `androidxLifecycle` | 2.8.7 | 2.10.0 |
| `androidxNavigation` | 2.8.5 | 2.9.8 |
| `androidxRoom` | 2.8.0 | 2.8.4 |
| `androidxWork` | 2.10.0 | 2.11.2 |
| `androidxActivity` | 1.10.1 | 1.13.0 |
| `androidxAppcompat` | 1.7.0 | 1.7.1 |
| `androidxConstraintlayout` | 2.2.0 | 2.2.1 |
| `androidxHilt` | 1.2.0 | 1.3.0 |
| `compileSdk` / `targetSdk` | 35 | 36 (forced floor for lifecycle 2.10 / nav 2.9) |
| `versionPatch` | 0 | 1 (`v4.0.0` → `v4.0.1-INTERNAL`) |

**Compose BOM intentionally NOT bumped** (still `2025.01.01`) — Compose surface needs its own validation phase separate from the AndroidX-core group bump.

## Code changes

One source file changed: `ui/main/MainScreen.kt` — `androidx.hilt.navigation.compose.hiltViewModel` → `androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel`. The function was relocated in androidx.hilt 1.3.0; old import still compiles via `@Deprecated` shim but emits a warning.

## Test plan

- [x] `./gradlew spotlessCheck`
- [x] `./gradlew detekt`
- [x] `./gradlew lintRelease`
- [x] `./gradlew assembleDebug`
- [x] `./gradlew test`
- [x] `./gradlew buildHealth`
- [x] `./gradlew koverVerify` (60% INSTRUCTION floor)
- [x] `./gradlew assembleRelease` (R8 + minify + lintVitalRelease — the v3.0.0 lesson validator)
- [ ] Manual device smoke before tagging `v4.0.1-INTERNAL` per pre-tag protocol (or one-off skip per user direction).

## Follow-ups (separate cleanup commits, not blocking)

- Lint baseline regen — 66 stale entries no longer apply.
- DAGP `kotlin-stdlib` `api` → `implementation` nit on `:app`.
- Investigate `Deprecated Gradle features were used` Gradle warning (likely a transitive plugin; identify with `--warning-mode all`).

Closes #78.

🤖 Generated with [Claude Code](https://claude.com/claude-code)