### PR TITLE
Phase 14c: macrobenchmark CI workflow + GMD provisioning

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,103 @@
+name: Macrobenchmark
+
+# Manual-only trigger. The macrobenchmark workflow provisions a Pixel 7 / API 34
+# AVD via AGP's Gradle Managed Devices, which downloads ~5 GB of system image
+# and adds 10–15 minutes per run — too expensive to gate every PR on. Cold-start
+# perf signal is informational until we have a baseline number to ratchet against
+# (Phase 14c scope: the workflow exists, the budgeting comes later if/when the
+# trace shows real headroom worth defending).
+#
+# To run: Actions tab → "Macrobenchmark" → "Run workflow" → choose `master` (or
+# any branch). The trace artifact is attached to the run on completion.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# Third-party actions pinned to commit SHAs with version-tag comments — same
+# supply-chain hardening as `build_pull_request.yml`. Dependabot's
+# `github-actions` ecosystem auto-bumps these on a weekly cadence.
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    env:
+      NASA_API_KEY: ${{ secrets.NASA_API_KEY }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      # KVM is the kernel module that lets the AVD run with hardware
+      # virtualization on the GitHub Actions Linux runner. Without these
+      # permissions the emulator falls back to software rendering and either
+      # times out or fails to boot. Pattern lifted from Now in Android's
+      # NightlyBaselineProfiles workflow.
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+          ls /dev/kvm
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@40fd30fb8d7440372e1316f5d1809ec01dcd3699 # v4.0.1
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
+
+      - name: Cache Gradle packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-bench-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-bench-
+            ${{ runner.os }}-gradle-
+
+      # Provision the Pixel 7 / API 34 GMD. Separate step so the system-image
+      # download (~5 GB) shows up clearly in the workflow timeline; failures
+      # here are usually quota / disk-space, not anything the benchmark code
+      # could surface. `swiftshader_indirect` GPU is the documented choice for
+      # headless CI runners (no host GPU passthrough).
+      - name: Provision pixel7Api34 managed device
+        run: ./gradlew :benchmark:pixel7Api34Setup
+          --info
+          -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true
+          -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
+
+      # Run the StartupBenchmark macrobenchmark on the GMD. Output is the
+      # cold-start TTFF metric across N iterations + a Perfetto trace per
+      # iteration. The trace is what we upload as an artifact; the headline
+      # number is in the gradle log.
+      - name: Run StartupBenchmark on pixel7Api34
+        run: ./gradlew :benchmark:pixel7Api34BenchmarkReleaseAndroidTest
+          -Pandroid.testoptions.manageddevices.emulator.gpu="swiftshader_indirect"
+          -Pandroid.experimental.testOptions.managedDevices.emulator.showKernelLogging=true
+
+      # `if: always()` so a benchmark failure still uploads partial output.
+      - name: Upload macrobenchmark traces and reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: macrobenchmark-traces
+          path: |
+            benchmark/build/outputs/managed_device_android_test_additional_output/**/*
+            benchmark/build/outputs/androidTest-results/**/*
+            benchmark/build/reports/androidTests/**/*
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -29,7 +29,9 @@ shippable; pick them off in order — each one stacks on the last.
 | 13a | Toolchain bump aligned to NIA (AGP 9 + Kotlin 2.3 + Hilt 2.59, drop kapt) | Done (#127) — folded 13c's kapt removal in via NIA's `ksp(kotlin-metadata)` pattern. Bumps to **`v4.0.0-INTERNAL`**. |
 | 13b | AndroidX group bump | Done (#129) — lifecycle 2.10, nav 2.9.8, room 2.8.4, work 2.11.2, +compileSdk/targetSdk 36. Bumps to **`v4.0.1-INTERNAL`**. Closes issue #78. |
 | 13c | Drop kapt for Hilt | Collapsed into 13a — the toolchain bump forced it (Hilt's metadata library version cap surfaced under Kotlin 2.3, and NIA's pattern was the documented fix). |
-| 14 | Baseline profiles + macrobenchmark | **Active** — graduated from "Quality bets". Compounds with Phase 12's cold-start work and Phase 5's Hilt graph. |
+| 14a | `:benchmark` module + `StartupBenchmark` | Done (#132) — first second-module in the project. AndroidX Macrobenchmark library on AGP-9-compatible `androidx.baselineprofile 1.5.0-alpha06`. |
+| 14b | `BaselineProfileGenerator` + checked-in `baseline-prof.txt` | Done (#133) — 20.7k-entry profile generated on Pixel 7 / API 33 emulator; bundles into AAB at `BUNDLE-METADATA/com.android.tools.build.profiles/baseline.prof`. Bumps to **`v4.0.2-INTERNAL`** (held untagged). |
+| 14c | CI workflow + GMD provisioning | **Active** — manual `workflow_dispatch` only; provisions Pixel 7 / API 34 GMD; uploads Perfetto traces as artifacts. Closes issue #131. |
 | — | **Module split** lands with feature #2, not as a phase | — |
 
 Tick the table when phases land. Each phase below lists scope, rationale, and
@@ -70,9 +72,14 @@ state at 2026-05-08, after Phase 13 closed end-to-end (`v4.0.0-INTERNAL` +
     2.10, nav 2.9.8, room 2.8.4, work 2.11.2, +compileSdk/targetSdk 36).
     Tagged without device smoke (workflow run `25576639557`). Closes
     issue #78 cleanly via `Closes #78`.
-- **Next pickup**: Phase 14 — baseline profiles + macrobenchmark module.
-  New `:benchmark` module (project's first second-module). `StartupBenchmark`
-  + `BaselineProfileGenerator` driving the four golden-path flows.
+  - `v4.0.2-INTERNAL` *(tag held)* — Phase 14 (#132 + #133 + 14c TBD). Per
+    user direction at the close of 14b's session, **Phase 14 ships as one
+    tag covering all three sub-PRs** instead of three separate cuts. Tag
+    pushes when 14c lands.
+- **Next pickup**: Phase 14c — CI workflow + GMD provisioning. Manual
+  `workflow_dispatch` runs `:benchmark:pixel7Api34BenchmarkReleaseAndroidTest`
+  on an AGP-provisioned Pixel 7 / API 34 AVD; uploads Perfetto traces as
+  artifacts. Not gating any PR — informational signal only.
 
 ### Issue close-keyword lesson (2026-05-08)
 


### PR DESCRIPTION
## Summary

- New `.github/workflows/benchmark.yml` — manual `workflow_dispatch` only. Provisions a Pixel 7 / API 34 AVD via AGP's Gradle Managed Devices, runs `:benchmark:pixel7Api34BenchmarkReleaseAndroidTest`, uploads Perfetto traces.
- Pattern lifted from Now in Android's `NightlyBaselineProfiles.yaml` (operating principle 6 — consult NIA before negotiating scope on Gradle/AGP/CI work).
- Third-party actions SHA-pinned with version-tag comments to match `build_pull_request.yml`.
- Plan: Phase 14 row split into 14a/b/c, all three now done.

## Why workflow_dispatch only (not on every PR)

GMD provisioning downloads ~5 GB system image and adds 10–15 minutes per run. Cold-start perf signal stays informational until we have a baseline number to ratchet against — not worth gating every PR on. NIA cron-runs theirs nightly; for an internal-track solo project, manual is the right cadence.

## After merge

Phase 14 ships as **one** `v4.0.2-INTERNAL` tag covering 14a + 14b + 14c (per user direction at close of 14b session). Tag push + GitHub Release happen post-merge.

## Test plan

- [ ] PR's existing `build_pull_request.yml` passes (this PR adds a workflow file but doesn't change any compile/test surface).
- [ ] Post-merge: trigger the new "Macrobenchmark" workflow manually from the Actions tab on `master` to validate end-to-end (this is the actual GMD provisioning + benchmark run; can't be exercised in PR CI without burning runner minutes pre-merge).
- [ ] Verify the `macrobenchmark-traces` artifact appears on the workflow run and contains at least one Perfetto trace + JUnit XML.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)