### PR TITLE
Phase 15a: structured logging — sealed events + Logger interface + TimberLogger sink

### DIFF
--- a/app/src/main/java/com/tarek/asteroidradar/AsteroidRadarApplication.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/AsteroidRadarApplication.kt
@@ -38,6 +38,8 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import coil.ImageLoader
 import coil.ImageLoaderFactory
+import com.tarek.asteroidradar.log.LogEvent
+import com.tarek.asteroidradar.log.Logger
 import com.tarek.asteroidradar.work.RefreshDataWorker
 import dagger.Lazy
 import dagger.hilt.android.HiltAndroidApp
@@ -62,6 +64,12 @@ class AsteroidRadarApplication :
     // the field by the time Coil calls newImageLoader().
     @Inject lateinit var imageLoader: Lazy<ImageLoader>
 
+    // Populated by Hilt during super.onCreate(); safe to use in the body of
+    // onCreate() once super has returned. The DebugTree below is what makes
+    // TimberLogger's output visible in Logcat — TimberLogger writes through
+    // Timber.tag(...).<level>(...), which routes to all planted trees.
+    @Inject lateinit var logger: Logger
+
     // The default WorkManagerInitializer is removed in the manifest so this
     // is read by WorkManager.getInstance() lazily — after Hilt has populated
     // workerFactory in onCreate. Reading it earlier would NPE the lateinit.
@@ -77,6 +85,7 @@ class AsteroidRadarApplication :
     override fun onCreate() {
         super.onCreate()
         Timber.plant(Timber.DebugTree())
+        logger.log(LogEvent.App.Launched)
         delayedInit()
     }
 

--- a/app/src/main/java/com/tarek/asteroidradar/di/LoggerModule.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/di/LoggerModule.kt
@@ -28,50 +28,28 @@
  */
 package com.tarek.asteroidradar.di
 
-import android.content.Context
-import androidx.room.Room
-import com.tarek.asteroidradar.database.AsteroidDao
-import com.tarek.asteroidradar.database.AsteroidDatabase
-import com.tarek.asteroidradar.database.MIGRATION_1_2
-import com.tarek.asteroidradar.database.PictureOfDayDao
+import com.tarek.asteroidradar.log.CompositeLogger
 import com.tarek.asteroidradar.log.Logger
-import com.tarek.asteroidradar.network.AsteroidService
-import com.tarek.asteroidradar.repository.AsteroidRepository
+import com.tarek.asteroidradar.log.TimberLogger
+import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
-import javax.inject.Singleton
+import dagger.multibindings.IntoSet
 
 @Module
 @InstallIn(SingletonComponent::class)
-object DatabaseModule {
-    @Provides
-    @Singleton
-    fun provideAsteroidDatabase(
-        @ApplicationContext context: Context,
-    ): AsteroidDatabase =
-        Room
-            .databaseBuilder(
-                context,
-                AsteroidDatabase::class.java,
-                "asteroids",
-            ).addMigrations(MIGRATION_1_2)
-            .build()
+abstract class LoggerModule {
+    // Each sink contributes itself to the multibound `Set<Logger>`. New sinks
+    // (e.g. CrashlyticsLogger in Phase 15b) add one more `@Binds @IntoSet`
+    // line here; nothing else changes.
+    @Binds
+    @IntoSet
+    abstract fun bindsTimberLoggerIntoSet(impl: TimberLogger): Logger
 
-    @Provides
-    fun provideAsteroidDao(database: AsteroidDatabase): AsteroidDao = database.asteroidDao
-
-    @Provides
-    fun providePictureOfDayDao(database: AsteroidDatabase): PictureOfDayDao = database.pictureOfDayDao
-
-    @Provides
-    @Singleton
-    fun provideAsteroidRepository(
-        asteroidDao: AsteroidDao,
-        pictureOfDayDao: PictureOfDayDao,
-        asteroidService: AsteroidService,
-        logger: Logger,
-    ): AsteroidRepository = AsteroidRepository(asteroidDao, pictureOfDayDao, asteroidService, logger)
+    // The singular `Logger` binding consumers inject. CompositeLogger reads
+    // the set and forwards to every sink. This is a separate binding key from
+    // `Set<Logger>` — CompositeLogger won't recursively inject itself.
+    @Binds
+    abstract fun bindsLogger(impl: CompositeLogger): Logger
 }

--- a/app/src/main/java/com/tarek/asteroidradar/log/CompositeLogger.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/log/CompositeLogger.kt
@@ -26,52 +26,22 @@
  * I, the author of the project, allow you to check the code as a reference, but
  * if you submit it, it's your own responsibility if you get expelled.
  */
-package com.tarek.asteroidradar.di
+package com.tarek.asteroidradar.log
 
-import android.content.Context
-import androidx.room.Room
-import com.tarek.asteroidradar.database.AsteroidDao
-import com.tarek.asteroidradar.database.AsteroidDatabase
-import com.tarek.asteroidradar.database.MIGRATION_1_2
-import com.tarek.asteroidradar.database.PictureOfDayDao
-import com.tarek.asteroidradar.log.Logger
-import com.tarek.asteroidradar.network.AsteroidService
-import com.tarek.asteroidradar.repository.AsteroidRepository
-import dagger.Module
-import dagger.Provides
-import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
-import dagger.hilt.components.SingletonComponent
+import javax.inject.Inject
 import javax.inject.Singleton
 
-@Module
-@InstallIn(SingletonComponent::class)
-object DatabaseModule {
-    @Provides
-    @Singleton
-    fun provideAsteroidDatabase(
-        @ApplicationContext context: Context,
-    ): AsteroidDatabase =
-        Room
-            .databaseBuilder(
-                context,
-                AsteroidDatabase::class.java,
-                "asteroids",
-            ).addMigrations(MIGRATION_1_2)
-            .build()
-
-    @Provides
-    fun provideAsteroidDao(database: AsteroidDatabase): AsteroidDao = database.asteroidDao
-
-    @Provides
-    fun providePictureOfDayDao(database: AsteroidDatabase): PictureOfDayDao = database.pictureOfDayDao
-
-    @Provides
-    @Singleton
-    fun provideAsteroidRepository(
-        asteroidDao: AsteroidDao,
-        pictureOfDayDao: PictureOfDayDao,
-        asteroidService: AsteroidService,
-        logger: Logger,
-    ): AsteroidRepository = AsteroidRepository(asteroidDao, pictureOfDayDao, asteroidService, logger)
-}
+// Hilt-managed dispatcher. The `Set<Logger>` injection point only resolves to
+// bindings contributed via `@IntoSet` in LoggerModule (currently just
+// TimberLogger); CompositeLogger itself is bound to the singular `Logger`
+// binding, so it can't end up in its own input set.
+@Singleton
+class CompositeLogger
+    @Inject
+    constructor(
+        private val sinks: Set<@JvmSuppressWildcards Logger>,
+    ) : Logger {
+        override fun log(event: LogEvent) {
+            sinks.forEach { it.log(event) }
+        }
+    }

--- a/app/src/main/java/com/tarek/asteroidradar/log/LogEvent.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/log/LogEvent.kt
@@ -1,0 +1,107 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.log
+
+// Typed event taxonomy. Each concrete event carries everything a sink needs to
+// render the call without the caller having to think about formatting: tag,
+// priority, message, optional structured attributes, and an optional cause.
+// New domains add nested sealed groups; new events in a domain add concrete
+// data classes / objects to that group.
+sealed class LogEvent {
+    abstract val tag: String
+    abstract val priority: LogPriority
+    abstract val message: String
+    open val attributes: Map<String, Any> = emptyMap()
+    open val throwable: Throwable? = null
+
+    sealed class Network : LogEvent() {
+        override val tag: String = "Network"
+
+        data class RefreshAsteroidsFailed(
+            val cause: Throwable,
+        ) : Network() {
+            override val priority: LogPriority = LogPriority.Warn
+            override val message: String = "refreshAsteroids() failed"
+            override val attributes: Map<String, Any> = causeAttributes(cause)
+            override val throwable: Throwable? = cause
+        }
+
+        data class RefreshPictureOfDayFailed(
+            val cause: Throwable,
+        ) : Network() {
+            override val priority: LogPriority = LogPriority.Warn
+            override val message: String = "refreshPictureOfDay() failed"
+            override val attributes: Map<String, Any> = causeAttributes(cause)
+            override val throwable: Throwable? = cause
+        }
+    }
+
+    sealed class App : LogEvent() {
+        override val tag: String = "App"
+
+        data object Launched : App() {
+            override val priority: LogPriority = LogPriority.Info
+            override val message: String = "application onCreate"
+        }
+    }
+
+    sealed class Work : LogEvent() {
+        override val tag: String = "Work"
+
+        // Failure here means doWork() returned Result.failure() — a non-retryable
+        // outcome. Retry is the WorkManager-managed back-off path; Success is the
+        // happy path. The enum is local to Work because no other domain consumes
+        // it today.
+        enum class Outcome { Success, Retry, Failure }
+
+        data object RefreshDataWorkerStarted : Work() {
+            override val priority: LogPriority = LogPriority.Info
+            override val message: String = "RefreshDataWorker started"
+        }
+
+        data class RefreshDataWorkerFinished(
+            val durationMs: Long,
+            val outcome: Outcome,
+        ) : Work() {
+            override val priority: LogPriority =
+                if (outcome == Outcome.Success) LogPriority.Info else LogPriority.Warn
+            override val message: String = "RefreshDataWorker finished outcome=${outcome.name}"
+            override val attributes: Map<String, Any> = mapOf("durationMs" to durationMs)
+        }
+    }
+
+    private companion object {
+        // Pulled out of the Network classes so both events render the same
+        // `cause=<message-or-classname>` attribute for downstream sinks.
+        fun causeAttributes(cause: Throwable): Map<String, Any> {
+            val text = cause.message ?: cause::class.simpleName.orEmpty()
+            return mapOf("cause" to text)
+        }
+    }
+}

--- a/app/src/main/java/com/tarek/asteroidradar/log/LogEvent.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/log/LogEvent.kt
@@ -91,8 +91,18 @@ sealed class LogEvent {
         ) : Work() {
             override val priority: LogPriority =
                 if (outcome == Outcome.Success) LogPriority.Info else LogPriority.Warn
-            override val message: String = "RefreshDataWorker finished outcome=${outcome.name}"
-            override val attributes: Map<String, Any> = mapOf("durationMs" to durationMs)
+            override val message: String = "RefreshDataWorker finished"
+
+            // Both fields live in the structured attribute map so remote sinks
+            // (Crashlytics customKeys, Datadog log attributes) can index each
+            // as a searchable field. TimberLogger flattens this back into a
+            // `key=value` suffix on the rendered message, so Logcat output is
+            // identical to the message-baked-in shape.
+            override val attributes: Map<String, Any> =
+                mapOf(
+                    "outcome" to outcome.name,
+                    "durationMs" to durationMs,
+                )
         }
     }
 

--- a/app/src/main/java/com/tarek/asteroidradar/log/LogPriority.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/log/LogPriority.kt
@@ -1,0 +1,41 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.log
+
+// Platform-independent severity for LogEvent. Sinks (TimberLogger, the future
+// CrashlyticsLogger) map this to their own level type. Kept out of
+// `android.util.Log` so plain JVM unit tests don't need a stubbed Android
+// classpath to construct events.
+enum class LogPriority {
+    Verbose,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}

--- a/app/src/main/java/com/tarek/asteroidradar/log/Logger.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/log/Logger.kt
@@ -1,0 +1,40 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.log
+
+// Single contract for both sides of the fanout:
+//   - Sinks (TimberLogger, future CrashlyticsLogger) implement Logger and are
+//     contributed to the multibound `Set<Logger>` via Hilt `@IntoSet`.
+//   - Consumers (Application, Repository, ViewModel, Worker) inject Logger
+//     and receive the singular CompositeLogger binding, which iterates the
+//     set. Multibinding keeps the two roles in separate Hilt bindings even
+//     though both expose `log(event)`.
+fun interface Logger {
+    fun log(event: LogEvent)
+}

--- a/app/src/main/java/com/tarek/asteroidradar/log/TimberLogger.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/log/TimberLogger.kt
@@ -26,52 +26,37 @@
  * I, the author of the project, allow you to check the code as a reference, but
  * if you submit it, it's your own responsibility if you get expelled.
  */
-package com.tarek.asteroidradar.di
+package com.tarek.asteroidradar.log
 
-import android.content.Context
-import androidx.room.Room
-import com.tarek.asteroidradar.database.AsteroidDao
-import com.tarek.asteroidradar.database.AsteroidDatabase
-import com.tarek.asteroidradar.database.MIGRATION_1_2
-import com.tarek.asteroidradar.database.PictureOfDayDao
-import com.tarek.asteroidradar.log.Logger
-import com.tarek.asteroidradar.network.AsteroidService
-import com.tarek.asteroidradar.repository.AsteroidRepository
-import dagger.Module
-import dagger.Provides
-import dagger.hilt.InstallIn
-import dagger.hilt.android.qualifiers.ApplicationContext
-import dagger.hilt.components.SingletonComponent
+import timber.log.Timber
+import javax.inject.Inject
 import javax.inject.Singleton
 
-@Module
-@InstallIn(SingletonComponent::class)
-object DatabaseModule {
-    @Provides
-    @Singleton
-    fun provideAsteroidDatabase(
-        @ApplicationContext context: Context,
-    ): AsteroidDatabase =
-        Room
-            .databaseBuilder(
-                context,
-                AsteroidDatabase::class.java,
-                "asteroids",
-            ).addMigrations(MIGRATION_1_2)
-            .build()
+// The Logcat sink. Routes every event through Timber so the existing
+// DebugTree planted in AsteroidRadarApplication.onCreate still picks the
+// calls up. The TimberLogger is the only place left in `main` that should
+// reference `timber.log.Timber.<level>(...)` — all other call sites go
+// through Logger.log(LogEvent.*).
+@Singleton
+class TimberLogger
+    @Inject
+    constructor() : Logger {
+        override fun log(event: LogEvent) {
+            val tree = Timber.tag(event.tag)
+            val rendered = event.message + event.attributes.toSuffix()
+            when (event.priority) {
+                LogPriority.Verbose -> tree.v(event.throwable, rendered)
+                LogPriority.Debug -> tree.d(event.throwable, rendered)
+                LogPriority.Info -> tree.i(event.throwable, rendered)
+                LogPriority.Warn -> tree.w(event.throwable, rendered)
+                LogPriority.Error -> tree.e(event.throwable, rendered)
+            }
+        }
 
-    @Provides
-    fun provideAsteroidDao(database: AsteroidDatabase): AsteroidDao = database.asteroidDao
-
-    @Provides
-    fun providePictureOfDayDao(database: AsteroidDatabase): PictureOfDayDao = database.pictureOfDayDao
-
-    @Provides
-    @Singleton
-    fun provideAsteroidRepository(
-        asteroidDao: AsteroidDao,
-        pictureOfDayDao: PictureOfDayDao,
-        asteroidService: AsteroidService,
-        logger: Logger,
-    ): AsteroidRepository = AsteroidRepository(asteroidDao, pictureOfDayDao, asteroidService, logger)
-}
+        private fun Map<String, Any>.toSuffix(): String =
+            if (isEmpty()) {
+                ""
+            } else {
+                entries.joinToString(prefix = " ", separator = " ") { "${it.key}=${it.value}" }
+            }
+    }

--- a/app/src/main/java/com/tarek/asteroidradar/repository/AsteroidRepository.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/repository/AsteroidRepository.kt
@@ -34,6 +34,8 @@ import com.tarek.asteroidradar.database.PictureOfDayDao
 import com.tarek.asteroidradar.database.asDomainModel
 import com.tarek.asteroidradar.domain.Asteroid
 import com.tarek.asteroidradar.domain.PictureOfDay
+import com.tarek.asteroidradar.log.LogEvent
+import com.tarek.asteroidradar.log.Logger
 import com.tarek.asteroidradar.network.AsteroidService
 import com.tarek.asteroidradar.network.asDatabaseModel
 import com.tarek.asteroidradar.network.parseAsteroidsJsonResult
@@ -42,13 +44,13 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
-import timber.log.Timber
 import java.time.LocalDate
 
 class AsteroidRepository(
     private val asteroidDao: AsteroidDao,
     private val pictureOfDayDao: PictureOfDayDao,
     private val asteroidService: AsteroidService,
+    private val logger: Logger,
 ) {
     sealed class AsteroidsFilter {
         data object TODAY : AsteroidsFilter()
@@ -98,7 +100,7 @@ class AsteroidRepository(
                     asteroidService.getImageOfDay(API_KEY).asDatabaseModel(),
                 )
             } catch (e: Exception) {
-                Timber.d("AsteroidRepository: refreshPictureOfDay() failed %s", e.message)
+                logger.log(LogEvent.Network.RefreshPictureOfDayFailed(e))
             }
         }
     }
@@ -112,7 +114,7 @@ class AsteroidRepository(
                         .asDatabaseModel(),
                 )
             } catch (e: Exception) {
-                Timber.d("AsteroidRepository: refreshAsteroids() failed %s", e.message)
+                logger.log(LogEvent.Network.RefreshAsteroidsFailed(e))
             }
         }
     }

--- a/app/src/main/java/com/tarek/asteroidradar/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/ui/main/MainViewModel.kt
@@ -31,6 +31,8 @@ package com.tarek.asteroidradar.ui.main
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.tarek.asteroidradar.domain.PictureOfDay
+import com.tarek.asteroidradar.log.LogEvent
+import com.tarek.asteroidradar.log.Logger
 import com.tarek.asteroidradar.repository.AsteroidRepository
 import com.tarek.asteroidradar.repository.AsteroidRepository.AsteroidsFilter
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -42,7 +44,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import timber.log.Timber
 import javax.inject.Inject
 
 private const val SUBSCRIPTION_TIMEOUT_MS = 5_000L
@@ -53,6 +54,7 @@ class MainViewModel
     @Inject
     constructor(
         private val repository: AsteroidRepository,
+        private val logger: Logger,
     ) : ViewModel() {
         // Issue #116: APOD is sourced from Room, not the network. The cached
         // row paints immediately on cold start; refreshPictureOfDay() runs in
@@ -93,7 +95,7 @@ class MainViewModel
             try {
                 repository.refreshPictureOfDay()
             } catch (e: Exception) {
-                Timber.d("MainViewModel: refreshPictureOfDay() failed : %s", e.message)
+                logger.log(LogEvent.Network.RefreshPictureOfDayFailed(e))
             }
         }
 
@@ -101,7 +103,7 @@ class MainViewModel
             try {
                 repository.refreshAsteroids()
             } catch (e: Exception) {
-                Timber.d("MainViewModel: refreshAsteroids() failed : %s", e.message)
+                logger.log(LogEvent.Network.RefreshAsteroidsFailed(e))
             }
         }
 

--- a/app/src/main/java/com/tarek/asteroidradar/work/RefreshDataWorker.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/work/RefreshDataWorker.kt
@@ -32,6 +32,8 @@ import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
+import com.tarek.asteroidradar.log.LogEvent
+import com.tarek.asteroidradar.log.Logger
 import com.tarek.asteroidradar.repository.AsteroidRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
@@ -44,6 +46,7 @@ class RefreshDataWorker
         @Assisted appContext: Context,
         @Assisted params: WorkerParameters,
         private val repository: AsteroidRepository,
+        private val logger: Logger,
     ) : CoroutineWorker(
             appContext,
             params,
@@ -52,12 +55,35 @@ class RefreshDataWorker
             const val WORK_NAME = "RefreshDataWorker"
         }
 
-        override suspend fun doWork(): Result =
-            try {
-                repository.deletePastAsteroids()
-                repository.refreshAsteroids()
-                Result.success()
-            } catch (e: HttpException) {
-                Result.retry()
+        override suspend fun doWork(): Result {
+            logger.log(LogEvent.Work.RefreshDataWorkerStarted)
+            val start = System.currentTimeMillis()
+            // Track the outcome alongside the Result rather than pattern-matching
+            // the returned Result post-hoc. `Result.Success`/`Result.Retry` are
+            // annotated @RestrictTo(LIBRARY_GROUP) in androidx.work, so external
+            // code can't reference them as types — only construct via the
+            // factory functions and treat them opaquely. The `finally` keeps
+            // the lifecycle event firing even if a non-HttpException propagates
+            // out of repository.refreshAsteroids() (WorkManager would treat it
+            // as Result.failure() — we log Outcome.Failure before re-throwing).
+            var outcome: LogEvent.Work.Outcome = LogEvent.Work.Outcome.Failure
+            return try {
+                try {
+                    repository.deletePastAsteroids()
+                    repository.refreshAsteroids()
+                    outcome = LogEvent.Work.Outcome.Success
+                    Result.success()
+                } catch (e: HttpException) {
+                    outcome = LogEvent.Work.Outcome.Retry
+                    Result.retry()
+                }
+            } finally {
+                logger.log(
+                    LogEvent.Work.RefreshDataWorkerFinished(
+                        durationMs = System.currentTimeMillis() - start,
+                        outcome = outcome,
+                    ),
+                )
             }
+        }
     }

--- a/app/src/test/java/com/tarek/asteroidradar/log/CompositeLoggerTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/log/CompositeLoggerTest.kt
@@ -1,0 +1,63 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.log
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class CompositeLoggerTest {
+    @Test
+    fun `log fans out to every bound sink`() {
+        val sinkA = RecordingLogger()
+        val sinkB = RecordingLogger()
+        val composite = CompositeLogger(setOf(sinkA, sinkB))
+        val event = LogEvent.App.Launched
+
+        composite.log(event)
+
+        assertThat(sinkA.received).containsExactly(event)
+        assertThat(sinkB.received).containsExactly(event)
+    }
+
+    @Test
+    fun `log with no sinks bound is a no-op`() {
+        val composite = CompositeLogger(emptySet())
+
+        // Should not throw — verifies the empty-set fanout path.
+        composite.log(LogEvent.App.Launched)
+    }
+}
+
+private class RecordingLogger : Logger {
+    val received = mutableListOf<LogEvent>()
+
+    override fun log(event: LogEvent) {
+        received += event
+    }
+}

--- a/app/src/test/java/com/tarek/asteroidradar/log/TimberLoggerTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/log/TimberLoggerTest.kt
@@ -1,0 +1,140 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.log
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import timber.log.Timber
+import java.io.IOException
+
+// Priority constants from android.util.Log. Hard-coded as ints so the JVM
+// classpath doesn't need android.jar resolved — these are what Timber's
+// .v/.d/.i/.w/.e wrappers pass downstream into Tree.log(priority, ...).
+private const val INFO = 4
+private const val WARN = 5
+
+// Concrete LogEvent subtypes only: sealed-class hierarchies can't be extended
+// from the unit-test source set (Kotlin treats it as a different module), so
+// the routing is exercised through the events the codebase actually emits.
+// Verbose/Debug/Error priority `when` arms are not covered here — they're
+// trivial and will be covered organically when concrete events at those
+// priorities land.
+class TimberLoggerTest {
+    private lateinit var tree: RecordingTree
+    private lateinit var logger: TimberLogger
+
+    @Before
+    fun setUp() {
+        tree = RecordingTree()
+        Timber.plant(tree)
+        logger = TimberLogger()
+    }
+
+    @After
+    fun tearDown() {
+        Timber.uprootAll()
+    }
+
+    @Test
+    fun `Info priority routes to Timber i with the event tag and message`() {
+        logger.log(LogEvent.App.Launched)
+
+        with(tree.entries.single()) {
+            assertThat(priority).isEqualTo(INFO)
+            assertThat(tag).isEqualTo("App")
+            assertThat(message).isEqualTo("application onCreate")
+            assertThat(throwable).isNull()
+        }
+    }
+
+    @Test
+    fun `Warn priority routes to Timber w and forwards the throwable`() {
+        val cause = IOException("network down")
+
+        logger.log(LogEvent.Network.RefreshAsteroidsFailed(cause))
+
+        with(tree.entries.single()) {
+            assertThat(priority).isEqualTo(WARN)
+            assertThat(tag).isEqualTo("Network")
+            assertThat(throwable).isSameInstanceAs(cause)
+        }
+    }
+
+    @Test
+    fun `attributes append as key=value suffix to the message`() {
+        logger.log(
+            LogEvent.Work.RefreshDataWorkerFinished(
+                durationMs = 1234L,
+                outcome = LogEvent.Work.Outcome.Success,
+            ),
+        )
+
+        assertThat(tree.entries.single().message)
+            .isEqualTo("RefreshDataWorker finished outcome=Success durationMs=1234")
+    }
+
+    @Test
+    fun `event with no attributes has no message suffix`() {
+        logger.log(LogEvent.Work.RefreshDataWorkerStarted)
+
+        // Trailing space would be a bug — verify the empty-attributes branch.
+        assertThat(tree.entries.single().message).isEqualTo("RefreshDataWorker started")
+    }
+
+    @Test
+    fun `tag from event drives Timber tag for each domain`() {
+        logger.log(LogEvent.App.Launched)
+        logger.log(LogEvent.Network.RefreshPictureOfDayFailed(IOException("x")))
+        logger.log(LogEvent.Work.RefreshDataWorkerStarted)
+
+        assertThat(tree.entries.map { it.tag }).containsExactly("App", "Network", "Work").inOrder()
+    }
+}
+
+private class RecordingTree : Timber.Tree() {
+    data class Entry(
+        val priority: Int,
+        val tag: String?,
+        val message: String,
+        val throwable: Throwable?,
+    )
+
+    val entries = mutableListOf<Entry>()
+
+    override fun log(
+        priority: Int,
+        tag: String?,
+        message: String,
+        t: Throwable?,
+    ) {
+        entries += Entry(priority, tag, message, t)
+    }
+}

--- a/app/src/test/java/com/tarek/asteroidradar/repository/AsteroidRepositoryTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/repository/AsteroidRepositoryTest.kt
@@ -35,6 +35,8 @@ import com.tarek.asteroidradar.database.DatabasePictureOfDay
 import com.tarek.asteroidradar.database.PictureOfDayDao
 import com.tarek.asteroidradar.database.asDomainModel
 import com.tarek.asteroidradar.domain.PictureOfDay
+import com.tarek.asteroidradar.log.LogEvent
+import com.tarek.asteroidradar.log.Logger
 import com.tarek.asteroidradar.network.AsteroidService
 import com.tarek.asteroidradar.network.ImageOfTheDay
 import com.tarek.asteroidradar.repository.AsteroidRepository.AsteroidsFilter
@@ -57,6 +59,7 @@ class AsteroidRepositoryTest {
     private lateinit var dao: FakeAsteroidDao
     private lateinit var pictureOfDayDao: FakePictureOfDayDao
     private lateinit var service: FakeAsteroidService
+    private lateinit var logger: RecordingLogger
     private lateinit var repository: AsteroidRepository
 
     @Before
@@ -64,7 +67,8 @@ class AsteroidRepositoryTest {
         dao = FakeAsteroidDao()
         pictureOfDayDao = FakePictureOfDayDao()
         service = FakeAsteroidService()
-        repository = AsteroidRepository(dao, pictureOfDayDao, service)
+        logger = RecordingLogger()
+        repository = AsteroidRepository(dao, pictureOfDayDao, service, logger)
     }
 
     @Test
@@ -158,11 +162,13 @@ class AsteroidRepositoryTest {
     @Test
     fun `refreshAsteroids swallows network exceptions and leaves the DAO untouched`() =
         runTest {
-            service.asteroidsResult = { throw IOException("simulated network failure") }
+            val failure = IOException("simulated network failure")
+            service.asteroidsResult = { throw failure }
 
             repository.refreshAsteroids()
 
             assertThat(dao.insertAllCalls).isEmpty()
+            assertThat(logger.received).containsExactly(LogEvent.Network.RefreshAsteroidsFailed(failure))
         }
 
     @Test
@@ -189,11 +195,13 @@ class AsteroidRepositoryTest {
     @Test
     fun `refreshPictureOfDay swallows network exceptions and leaves the DAO untouched`() =
         runTest {
-            service.imageOfDayResult = { throw IOException("simulated network failure") }
+            val failure = IOException("simulated network failure")
+            service.imageOfDayResult = { throw failure }
 
             repository.refreshPictureOfDay()
 
             assertThat(pictureOfDayDao.insertCalls).isEmpty()
+            assertThat(logger.received).containsExactly(LogEvent.Network.RefreshPictureOfDayFailed(failure))
         }
 
     private fun asteroidEntity(
@@ -323,4 +331,12 @@ private class FakeAsteroidService : AsteroidService {
     override suspend fun getAsteroids(key: String): String = asteroidsResult()
 
     override suspend fun getImageOfDay(key: String): ImageOfTheDay = imageOfDayResult()
+}
+
+private class RecordingLogger : Logger {
+    val received = mutableListOf<LogEvent>()
+
+    override fun log(event: LogEvent) {
+        received += event
+    }
 }

--- a/app/src/test/java/com/tarek/asteroidradar/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/ui/main/MainViewModelTest.kt
@@ -32,6 +32,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.tarek.asteroidradar.domain.Asteroid
 import com.tarek.asteroidradar.domain.PictureOfDay
+import com.tarek.asteroidradar.log.Logger
 import com.tarek.asteroidradar.repository.AsteroidRepository
 import com.tarek.asteroidradar.repository.AsteroidRepository.AsteroidsFilter
 import io.mockk.coEvery
@@ -54,12 +55,14 @@ import org.junit.Test
 class MainViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private lateinit var repository: AsteroidRepository
+    private lateinit var logger: Logger
     private lateinit var pictureOfDayFlow: MutableStateFlow<PictureOfDay?>
 
     @Before
     fun setUp() {
         Dispatchers.setMain(testDispatcher)
         repository = mockk(relaxed = true)
+        logger = mockk(relaxed = true)
         pictureOfDayFlow = MutableStateFlow(null)
         // The init block kicks off both refresh paths; default both to no-op
         // so each test only stubs what it cares about. getPictureOfDay() is
@@ -78,7 +81,7 @@ class MainViewModelTest {
     @Test
     fun `init triggers parallel refresh of asteroids and APOD`() =
         runTest(testDispatcher) {
-            val viewModel = MainViewModel(repository)
+            val viewModel = MainViewModel(repository, logger)
             advanceUntilIdle()
 
             coVerify(exactly = 1) { repository.refreshAsteroids() }
@@ -90,7 +93,7 @@ class MainViewModelTest {
     @Test
     fun `imageOfTheDay mirrors the cached APOD flow`() =
         runTest(testDispatcher) {
-            val viewModel = MainViewModel(repository)
+            val viewModel = MainViewModel(repository, logger)
 
             viewModel.imageOfTheDay.test {
                 assertThat(awaitItem()).isNull()
@@ -108,7 +111,7 @@ class MainViewModelTest {
         runTest(testDispatcher) {
             coEvery { repository.refreshPictureOfDay() } throws RuntimeException("boom")
 
-            val viewModel = MainViewModel(repository)
+            val viewModel = MainViewModel(repository, logger)
             advanceUntilIdle()
 
             // Failure must not propagate; the cache flow is the source of truth.
@@ -125,7 +128,7 @@ class MainViewModelTest {
             every { repository.getAsteroidSelection(AsteroidsFilter.TODAY) } returns today
             every { repository.getAsteroidSelection(AsteroidsFilter.WEEK) } returns week
 
-            val viewModel = MainViewModel(repository)
+            val viewModel = MainViewModel(repository, logger)
             advanceUntilIdle()
 
             // Collect the StateFlow so flatMapLatest re-evaluates on each filter

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -32,6 +32,8 @@ shippable; pick them off in order — each one stacks on the last.
 | 14a | `:benchmark` module + `StartupBenchmark` | Done (#132) — first second-module in the project. AndroidX Macrobenchmark library on AGP-9-compatible `androidx.baselineprofile 1.5.0-alpha06`. |
 | 14b | `BaselineProfileGenerator` + checked-in `baseline-prof.txt` | Done (#133) — 20.7k-entry profile generated on Pixel 7 / API 33 emulator; bundles into AAB at `BUNDLE-METADATA/com.android.tools.build.profiles/baseline.prof`. Bumps to **`v4.0.2-INTERNAL`** (tag bundled with 14c). |
 | 14c | CI workflow + GMD provisioning | Done (#134) — manual `workflow_dispatch` only; provisions Pixel 7 / API 34 GMD; uploads Perfetto traces as artifacts. Closes issue #131. |
+| 15a | Logging architecture (sealed events + Logger interface + TimberLogger sink) | In progress (#151) — sealed `LogEvent` hierarchy + `Logger` interface + `CompositeLogger` fanout via Hilt `@IntoSet`. Migrates 4 existing `Timber.d` call sites and adds 2 `RefreshDataWorker` lifecycle events. Reference doc at `docs/patterns/structured-logging.md`. Part of umbrella #150. |
+| 15b | Firebase Crashlytics sink | Queued — adds `CrashlyticsLogger` as a second `@IntoSet` binding. Wires Firebase setup + `google-services.json`. Bumps to **`v4.0.3-INTERNAL`** when it lands. Part of umbrella #150. |
 | — | **Module split** lands with feature #2, not as a phase | — |
 
 Tick the table when phases land. Each phase below lists scope, rationale, and
@@ -760,6 +762,78 @@ added the Room read for the cached APOD; both affect cold-start budget).
 - Cheap to write, expensive to retrofit later. If we're going to do it,
   doing it before adding a second feature (where the macrobenchmark module
   pattern locks in) is the right time.
+
+## Phase 15 — Structured logging (sealed events + Hilt fanout)
+
+Goal: replace 4 ad-hoc `Timber.d(...)` printf-style call sites with a
+typed-event pattern (sealed `LogEvent` hierarchy + `Logger` interface +
+Hilt set-multibinding fanout), and use the migration as an educational
+worked example for a pattern the user wants to carry across projects.
+Tracked under umbrella issue #150 (rewritten 2026-05-18 from an
+Ultraplan-approved plan).
+
+The pattern is recovered from a past production project that used the
+same architecture with Datadog as the remote sink. Datadog is paid; for
+this educational, internal-test, solo project the substitution is:
+Logcat (via Timber) in 15a, Firebase Crashlytics (free) in 15b. The
+architecture is the educational deliverable — sinks are interchangeable.
+
+### Sub-PR breakdown
+
+- **15a (`feat/phase-15a-logging-architecture`).** Sealed `LogEvent` +
+  `Logger` interface + `CompositeLogger` + `TimberLogger`. Migrates
+  `AsteroidRadarApplication`, `AsteroidRepository`, `MainViewModel`, and
+  `RefreshDataWorker` to the typed API. Adds 2 new lifecycle events
+  (`Work.RefreshDataWorkerStarted` / `RefreshDataWorkerFinished`). Ships
+  the reference doc at `docs/patterns/structured-logging.md`. No runtime
+  dependency change (Timber stays; the existing `DebugTree` keeps Logcat
+  alive). Part of umbrella #150.
+- **15b (`feat/phase-15b-crashlytics-sink`).** Firebase Crashlytics SDK
+  + plugins + `CrashlyticsLogger` as a second `@IntoSet` binding. Adds
+  `google-services.json` (gitignored; CI decodes from a base64 secret).
+  Disables collection in debug builds via manifest meta-data. Bumps to
+  **`v4.0.3-INTERNAL`** when this lands. Closes umbrella #150.
+
+### Pattern reference
+
+`docs/patterns/structured-logging.md` is the load-bearing artifact —
+generic enough to copy into any Kotlin Android project. Includes the
+diagram, step-by-step recipe, pitfalls, and what the pattern is *not*
+(no RUM, no APM tracing, no log aggregation — those are sink concerns).
+
+### Things to watch
+
+- **`@JvmSuppressWildcards` on `Set<Logger>`.** Without it, Dagger's
+  generated `Set<? extends Logger>` collides with Kotlin variance and
+  the module fails to compile. Easy to forget when adding a second sink.
+- **Double-binding hygiene.** `TimberLogger` is bound via `@IntoSet` to
+  populate the set; `CompositeLogger` is bound via plain `@Binds` to be
+  the singular `Logger` consumers inject. These are separate Hilt keys —
+  if you accidentally add `@IntoSet` to the composite binding, you get a
+  recursive injection.
+- **`AsteroidRepository` is provided, not `@Inject`-constructed.**
+  Adding `Logger` to its constructor required updating `DatabaseModule`'s
+  `provideAsteroidRepository` factory. The existing tests instantiate
+  the repo directly with a recording fake; mockk wouldn't work here
+  because the test asserts on the captured events.
+- **Pre-existing double-log between Repository and ViewModel.** Noticed
+  during 15a: both `AsteroidRepository.refreshX` and `MainViewModel`'s
+  catch wrappers swallow + log. The ViewModel catch is dead code (the
+  repo already swallowed). 15a preserves this shape for minimal-diff
+  scope; cleanup is a separate one-PR refactor.
+
+### Out of scope
+
+- RUM (Real User Monitoring) and APM tracing — separate observability
+  surfaces, both paid in Datadog. Firebase Performance Monitoring is a
+  free RUM-ish alternative if cold-start regressions ever justify it.
+- Sentry as an alternative remote sink. Stays available as a drop-in
+  via a `SentryLogger` binding if Crashlytics proves insufficient.
+- NavController route tracking — auto-tagging events with the current
+  Compose Nav route would be a useful 15c. Worth doing if Crashlytics
+  breadcrumbs feel context-poor in practice.
+- Removing the double-swallow shape (Repository swallows + logs,
+  ViewModel re-catches dead code). Tracked as a follow-up PR.
 
 ## Quality bets to consider (capped at 3)
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -794,6 +794,36 @@ architecture is the educational deliverable — sinks are interchangeable.
   Disables collection in debug builds via manifest meta-data. Bumps to
   **`v4.0.3-INTERNAL`** when this lands. Closes umbrella #150.
 
+  **Cost gates (Gate 1 — build-type filtering).** Crashlytics's free
+  tier has per-session caps (≈8 non-fatals/session, 64 KB breadcrumbs)
+  rather than a monthly billing line — overshooting silently drops
+  data. To stay inside the caps without runtime infra, Phase 15b wires
+  the sink only into release builds via Hilt source-set splits:
+
+  - `app/src/main/java/.../di/LoggerModule.kt` — shared bindings.
+    `TimberLogger` binds into `Set<Logger>` here; visible to all
+    build types.
+  - `app/src/release/java/.../di/LoggerReleaseModule.kt` — release-only.
+    `CrashlyticsLogger` binds into `Set<Logger>` here. AGP's source-set
+    merging means the Hilt graph in release builds sees both sinks; the
+    debug graph sees only Timber.
+
+  **Gate 2 — severity floor inside `CrashlyticsLogger`.** The sink
+  short-circuits events below `LogPriority.Warn`, keeping Verbose/Debug
+  chatter local-only even in release builds. One `if (event.priority <
+  LogPriority.Warn) return` line in the sink — composes naturally with
+  the build-type split above. Drops the per-session non-fatal cap as a
+  practical concern: Crashlytics only sees events we actually want
+  surfaced.
+
+  **Gate 3 — decorator-based runtime filtering (out of scope for 15b).**
+  Firebase Remote Config + a `FlaggedLogger`/`SampledLogger` decorator
+  wrapper would let a noisy event-type be killed without a release.
+  Captured as a Phase 15c / quality-bet entry — overkill for the
+  internal-test cadence today, but the architecture supports it
+  (decorators slot into the existing `Logger` set-multibinding via a
+  `@Provides` factory; no call-site change).
+
 ### Pattern reference
 
 `docs/patterns/structured-logging.md` is the load-bearing artifact —

--- a/docs/patterns/structured-logging.md
+++ b/docs/patterns/structured-logging.md
@@ -1,0 +1,275 @@
+# Structured logging — sealed events + Hilt fanout
+
+A reusable pattern for Android logging that scales from "Logcat-only in
+debug" to "multi-sink remote observability" without touching call sites
+when you add or remove a sink.
+
+This document is the load-bearing reference: copy it into another Kotlin
+Android project, follow the recipe, get the same pattern. The worked
+example lives in `app/src/main/java/com/tarek/asteroidradar/log/`.
+
+## The problem with printf-style logging
+
+`Timber.d("Repository: refresh failed %s", e.message)` rots:
+
+- **Free-text messages** drift apart over time. Every call site invents
+  its own prefix ("Repository:", "MainViewModel:") and format.
+- **No typed payload.** Adding a new field (`durationMs`, `userId`) means
+  editing every call site that should carry it, and every grep that
+  needs to find them.
+- **No taxonomy.** Filtering by domain ("show me everything network-related")
+  relies on grepping prefixes, which has no compile-time guarantee.
+- **Sink lock-in.** When you eventually want to ship structured events
+  to Crashlytics / Sentry / Datadog, every call site has to learn the
+  new SDK. The migration is `O(call sites)`.
+
+The pattern below solves all four.
+
+## The pattern in one diagram
+
+```
+                   ┌─────────────────┐
+   call site ────▶ │   Logger (DI)   │ ─── interface, what consumers depend on
+                   └────────┬────────┘
+                            │
+                   ┌────────▼────────┐
+                   │ CompositeLogger │ ─── singular Hilt binding, fans out
+                   └────────┬────────┘
+                            │  Set<Logger>  (multibound via @IntoSet)
+                ┌───────────┼──────────────┐
+                ▼           ▼              ▼
+         ┌──────────┐ ┌───────────────┐ ┌──────────────┐
+         │ Timber   │ │  Crashlytics  │ │  …other      │
+         │ Logger   │ │  Logger       │ │  sinks       │
+         └──────────┘ └───────────────┘ └──────────────┘
+```
+
+Four moving parts:
+
+1. **`LogEvent`** — sealed taxonomy. Each concrete event carries a tag,
+   priority, message, optional attributes, and an optional `Throwable`.
+2. **`Logger`** — the contract. One method: `log(event: LogEvent)`.
+3. **`CompositeLogger`** — the dispatcher. Injects `Set<Logger>` and
+   forwards every event to every sink.
+4. **Hilt module** — wires sinks into the set (`@IntoSet`) and binds
+   `CompositeLogger` as the singular `Logger` consumers see.
+
+## Step 1 — Define `LogPriority`
+
+Platform-independent severity. Kept out of `android.util.Log` so JVM unit
+tests can construct events without an Android classpath.
+
+```kotlin
+enum class LogPriority { Verbose, Debug, Info, Warn, Error }
+```
+
+Sinks map this to their own level type (Timber's `.v/.d/.i/.w/.e`,
+Crashlytics's `setCustomKey`/`recordException`, etc.).
+
+## Step 2 — Define the `LogEvent` taxonomy
+
+Group concrete events by domain via nested `sealed class`es:
+
+```kotlin
+sealed class LogEvent {
+    abstract val tag: String
+    abstract val priority: LogPriority
+    abstract val message: String
+    open val attributes: Map<String, Any> = emptyMap()
+    open val throwable: Throwable? = null
+
+    sealed class Network : LogEvent() {
+        override val tag: String = "Network"
+
+        data class RequestFailed(
+            val url: String,
+            val cause: Throwable,
+        ) : Network() {
+            override val priority = LogPriority.Warn
+            override val message = "request_failed"
+            override val attributes: Map<String, Any> = mapOf("url" to url)
+            override val throwable: Throwable? = cause
+        }
+    }
+
+    sealed class App : LogEvent() {
+        override val tag: String = "App"
+
+        data object Launched : App() {
+            override val priority = LogPriority.Info
+            override val message = "application onCreate"
+        }
+    }
+}
+```
+
+Use `data object` for parameter-less events; `data class` for events with
+typed payloads. The compiler enforces that every concrete event provides
+the abstract properties — you can't forget a tag the way you can with
+`Timber.d("...")`.
+
+## Step 3 — The `Logger` contract
+
+```kotlin
+fun interface Logger {
+    fun log(event: LogEvent)
+}
+```
+
+A `fun interface` lets sinks be written as lambdas in tests, but the
+common case is a class implementation injected by Hilt.
+
+## Step 4 — Write a sink
+
+A sink is a `Logger` implementation that knows one rendering. Timber:
+
+```kotlin
+@Singleton
+class TimberLogger @Inject constructor() : Logger {
+    override fun log(event: LogEvent) {
+        val tree = Timber.tag(event.tag)
+        val msg = event.message + event.attributes.toSuffix()
+        when (event.priority) {
+            LogPriority.Verbose -> tree.v(event.throwable, msg)
+            LogPriority.Debug -> tree.d(event.throwable, msg)
+            LogPriority.Info -> tree.i(event.throwable, msg)
+            LogPriority.Warn -> tree.w(event.throwable, msg)
+            LogPriority.Error -> tree.e(event.throwable, msg)
+        }
+    }
+
+    private fun Map<String, Any>.toSuffix(): String =
+        if (isEmpty()) "" else entries.joinToString(
+            prefix = " ", separator = " ",
+        ) { "${it.key}=${it.value}" }
+}
+```
+
+A future remote sink (Crashlytics, Sentry) is exactly the same shape — a
+class implementing `Logger`, mapping the event into the SDK's API.
+
+## Step 5 — The composite dispatcher
+
+```kotlin
+@Singleton
+class CompositeLogger @Inject constructor(
+    private val sinks: Set<@JvmSuppressWildcards Logger>,
+) : Logger {
+    override fun log(event: LogEvent) {
+        sinks.forEach { it.log(event) }
+    }
+}
+```
+
+`@JvmSuppressWildcards` is required for Dagger multibinding sets in
+Kotlin — without it Hilt generates `Set<? extends Logger>` and refuses
+to inject your set.
+
+## Step 6 — The Hilt module
+
+```kotlin
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LoggerModule {
+    @Binds
+    @IntoSet
+    abstract fun bindsTimberLoggerIntoSet(impl: TimberLogger): Logger
+
+    @Binds
+    abstract fun bindsLogger(impl: CompositeLogger): Logger
+}
+```
+
+Two bindings, two roles:
+
+- `@IntoSet` contributions populate `Set<Logger>` — only TimberLogger here.
+- The plain `@Binds Logger` (no `@IntoSet`) is the singular `Logger`
+  binding consumers inject. Hilt sees them as separate binding keys —
+  `Set<Logger>` and `Logger` — so `CompositeLogger`'s injected set won't
+  accidentally include itself.
+
+## Step 7 — Call sites
+
+Anywhere that previously called `Timber.d(...)`:
+
+```kotlin
+class MainViewModel @Inject constructor(
+    private val repository: Repository,
+    private val logger: Logger,
+) : ViewModel() {
+    init {
+        viewModelScope.launch {
+            try {
+                repository.refresh()
+            } catch (e: Exception) {
+                logger.log(LogEvent.Network.RequestFailed(url = "/feed", cause = e))
+            }
+        }
+    }
+}
+```
+
+The call site only knows about `Logger` and `LogEvent`. Nothing else.
+
+## Adding a new sink — the payoff
+
+To add Sentry (or Crashlytics, or Datadog if you like burning money):
+
+1. Write `SentryLogger : Logger`.
+2. Add one line to `LoggerModule`:
+   `@Binds @IntoSet abstract fun bindsSentryLogger(impl: SentryLogger): Logger`.
+3. Done.
+
+Zero call-site changes. The fanout picks up the new sink automatically.
+
+## What this pattern is **not**
+
+- **Not RUM (Real User Monitoring).** RUM tracks session/screen
+  lifecycles via SDK-specific instrumentation (Firebase Performance,
+  Datadog RUM, Sentry Replays). It can complement structured logging but
+  isn't replaced by it.
+- **Not APM tracing.** Distributed tracing across mobile → backend
+  requires OkHttp interceptors + server-side span correlation. Out of
+  scope for the log path.
+- **Not log aggregation.** That's the sink's responsibility. The pattern
+  delivers events *to* a sink; getting them into a queryable dashboard
+  is the sink's problem.
+
+## Pitfalls to avoid
+
+- **Don't make `CompositeLogger` itself bind into the set.** A naïve
+  `@Binds @IntoSet abstract fun bindsComposite(impl: CompositeLogger): Logger`
+  would create a recursive injection. Keep the `@IntoSet` bindings to
+  sink-only types, and the singular `@Binds` binding to the composite.
+- **Don't forget `@JvmSuppressWildcards` on the `Set<Logger>` injection.**
+  Without it, Dagger's Java-flavored type signature collides with
+  Kotlin's variance and the module fails to compile.
+- **Don't forget to map nullability on `Throwable`.** If a concrete event
+  always carries a cause, declare the constructor parameter non-null
+  (`val cause: Throwable`) and assign it to the base override
+  (`override val throwable: Throwable? = cause`). Don't force callers
+  through nullability they shouldn't have to think about.
+- **Don't catch exceptions inside `CompositeLogger.log`.** If a sink
+  misbehaves, you want the error to surface — not get swallowed silently.
+  Add per-sink resilience inside the sink if you need it, not at the
+  fanout layer.
+
+## Alternative shapes worth knowing
+
+- **Timber-tree fanout** (sinks-as-`Timber.Tree` subclasses, call sites
+  stay `Timber.tag(...)..i(...)`). Lower ceremony, no event taxonomy,
+  no compile-time payload completeness. Good for tiny apps with one
+  remote sink. Bad if you want the typed-event benefits.
+- **Single Logger interface, Set injection at call site.** Skip
+  `CompositeLogger`; consumers inject `Set<Logger>` directly and iterate.
+  Saves a class but pushes the loop into every call site. Not worth it.
+- **NowInAndroid-style build-type swap.** `Stub*Helper` for debug,
+  `Firebase*Helper` for release, swapped via Hilt module variants. Works
+  for analytics where you typically want *one* impl per build type;
+  doesn't generalise to multi-sink fanout.
+
+## See also
+
+- `app/src/main/java/com/tarek/asteroidradar/log/` — the worked example.
+- `docs/IMPROVEMENT_PLAN.md` Phase 15 — the implementation history,
+  including the 15a / 15b split.

--- a/docs/patterns/structured-logging.md
+++ b/docs/patterns/structured-logging.md
@@ -54,6 +54,120 @@ Four moving parts:
 4. **Hilt module** — wires sinks into the set (`@IntoSet`) and binds
    `CompositeLogger` as the singular `Logger` consumers see.
 
+## Severity belongs to events, not loggers
+
+The deepest shift in the pattern, and the easiest one to miss. The old
+API made every call site decide two things at once:
+
+1. *What happened?* — encoded in the message string.
+2. *How loud?* — encoded in the method name (`.d`, `.i`, `.w`, `.e`).
+
+```kotlin
+Timber.d("Repository: refresh failed ${e.message}")
+//     ^                       ^
+//     severity: debug         payload: free text
+```
+
+In practice these get tangled. `Timber.d` is one keystroke shorter than
+`Timber.w`, so people reach for it. Cargo-culted prefixes ("Repository:")
+drift across files. The same kind of incident ends up logged at three
+different severities in three different places, because each developer
+was thinking about *content* and the severity slot was an afterthought.
+Filtering by severity in production becomes meaningless — every codebase
+of any age has real errors at `.d` and "FYI" messages at `.e`.
+
+The typed-event pattern **separates the two decisions**:
+
+```kotlin
+// Call site only decides what happened:
+logger.log(LogEvent.Network.RefreshFailed(e))
+
+// The event class declares the severity once, for everyone:
+data class RefreshFailed(val cause: Throwable) : Network() {
+    override val priority = LogPriority.Warn   // single source of truth
+    override val message = "refresh_failed"
+    override val throwable: Throwable? = cause
+}
+```
+
+Decide later that all network failures should escalate to
+`LogPriority.Error`? Change one line in the event. Every call site
+upgrades automatically. The opposite is impossible with `.d`/`.e`
+methods on the logger — you'd have to grep every file in the codebase.
+
+### Where do `.d` / `.e` / `.i` go?
+
+Down to the sink. Each sink has a single `when` block that maps
+`LogPriority` to its medium's level API:
+
+```kotlin
+// TimberLogger.kt — the only file in `main` that knows about Timber's
+// .v/.d/.i/.w/.e methods.
+override fun log(event: LogEvent) {
+    val tree = Timber.tag(event.tag)
+    when (event.priority) {
+        LogPriority.Verbose -> tree.v(event.throwable, rendered)
+        LogPriority.Debug   -> tree.d(event.throwable, rendered)
+        LogPriority.Info    -> tree.i(event.throwable, rendered)
+        LogPriority.Warn    -> tree.w(event.throwable, rendered)
+        LogPriority.Error   -> tree.e(event.throwable, rendered)
+    }
+}
+```
+
+Everywhere else, code talks in events.
+
+### Sinks pick their own mapping
+
+The mapping is **semantic, not mechanical** — each sink decides what each
+priority means *for its medium*. Crashlytics, for instance, doesn't have
+a five-level API at all. It has two distinct mechanisms:
+
+- `FirebaseCrashlytics.log(message)` — adds a breadcrumb.
+- `FirebaseCrashlytics.recordException(throwable)` — files a non-fatal.
+
+So a `CrashlyticsLogger` collapses the priorities into the two
+behaviors that exist:
+
+```kotlin
+override fun log(event: LogEvent) {
+    val crashlytics = FirebaseCrashlytics.getInstance()
+    event.attributes.forEach { (k, v) -> crashlytics.setCustomKey(k, v.toString()) }
+    val line = "[${event.tag}] ${event.message}"
+    when (event.priority) {
+        LogPriority.Verbose, LogPriority.Debug,
+        LogPriority.Info, LogPriority.Warn ->
+            crashlytics.log(line)
+        LogPriority.Error -> {
+            crashlytics.log(line)
+            event.throwable?.let { crashlytics.recordException(it) }
+        }
+    }
+}
+```
+
+Five priorities collapse to two semantic behaviors (breadcrumb vs.
+non-fatal). A future `DatadogLogger` might map one-to-one (Datadog's
+SDK has a matching five-level enum). A `SentryLogger` might fold
+Verbose/Debug into "no-op for prod" and Error into a captured event.
+Events stay the same; only the per-sink mapping changes.
+
+### What this buys you
+
+| Concern | Free-text Timber | Typed events |
+|---|---|---|
+| *What happened?* | mixed into the message string | the event subtype |
+| *How loud is it?* | each caller picks (`.d` vs `.e`) | a property of the event |
+| *Which sink renders it?* | hard-coded to Timber | sink picks its own mapping |
+| *What payload travels with it?* | printf args, no types | typed `Map<String, Any>` |
+| *Filtering by severity in prod* | unreliable (callers drift) | reliable (event is the floor) |
+
+The biggest win isn't the type safety — it's **filter-reliability**.
+When severity is a property of the incident type, "show me all warnings"
+in your log explorer actually corresponds to a stable, predictable set
+of things. With per-call-site `.d`/`.e` choices, severity filters are
+noise.
+
 ## Step 1 — Define `LogPriority`
 
 Platform-independent severity. Kept out of `android.util.Log` so JVM unit


### PR DESCRIPTION
## Summary

Introduces the typed-event logging pattern (sealed `LogEvent` hierarchy + `Logger` interface + `CompositeLogger` fanout via Hilt set-multibinding) with a single sink today (`TimberLogger`, routing through the existing DebugTree). The pattern was recovered from a past observability-heavy project where Datadog was the remote sink; this PR ports the architecture, and 15b will add Firebase Crashlytics as a second `@IntoSet` binding with zero call-site change.

Migration:
- 4 `Timber.d(...)` call sites in `AsteroidRepository` + `MainViewModel` → `LogEvent.Network.Refresh*Failed(throwable)` events.
- `AsteroidRadarApplication.onCreate()` emits `LogEvent.App.Launched` after the DebugTree plants.
- `RefreshDataWorker.doWork()` wrapped in a try/finally that emits `Work.RefreshDataWorkerStarted` / `RefreshDataWorkerFinished(durationMs, outcome)` — new instrumentation, no prior logging here.

New: `log/{LogPriority, LogEvent, Logger, CompositeLogger, TimberLogger}.kt`, `di/LoggerModule.kt`, two new test files, `docs/patterns/structured-logging.md` (the educational deliverable — generic enough to copy into another Kotlin Android project).

Part of #150. Refs #151.

## Design notes

- **`LogPriority` is a project-defined enum**, not `android.util.Log` constants, so JVM unit tests don't need `android.jar` resolved.
- **`LogEvent` stays sealed**: closes the taxonomy. Test priority-routing coverage for Verbose/Debug/Error `when` arms is omitted because cross-module sealed-class extension is prohibited (test source set is a separate Kotlin module) — the mapping is trivial and visual review > workaround machinery for this slice.
- **`RefreshDataWorker` tracks outcome alongside the Result** instead of pattern-matching post-hoc — `Result.Success` / `Result.Retry` are `@RestrictTo(LIBRARY_GROUP)` in androidx.work and lint errors on the `is` check.
- **`AsteroidRepository` is constructed via `DatabaseModule.provideAsteroidRepository`** (not `@Inject` constructor), so the `Logger` thread runs through the factory; existing `AsteroidRepositoryTest` instantiations updated with a `RecordingLogger` fake that doubles as a way to assert on captured events.
- **`MainViewModelTest` mocks `Logger`** via mockk's relaxed mode (consistent with how `AsteroidRepository` is mocked there).

## Out of scope (called out in the doc + IMPROVEMENT_PLAN)

- Firebase Crashlytics sink — Phase 15b.
- Removing the existing Repository-and-ViewModel double-swallow (the ViewModel catch is dead code; the repo already swallows). Preserved for minimal-diff scope; future cleanup PR.
- RUM, APM tracing, Sentry alternative, NavController route tracking.

## Test plan

- [x] `./gradlew spotlessCheck` — green.
- [x] `./gradlew detekt` — green.
- [x] `./gradlew :app:testDebugUnitTest` — green (incl. new `CompositeLoggerTest` + `TimberLoggerTest`).
- [x] `./gradlew assembleDebug` — green.
- [x] `./gradlew lintRelease` — green.
- [x] `./gradlew buildHealth` — green (one pre-existing advisory on `androidx.hilt.navigation.compose` unrelated to this PR; left for a separate cleanup).
- [ ] On-device cold-start smoke (debug APK on Pixel 7 / API 34 AVD): confirm `App.Launched` + `Work.*` events surface in Logcat tagged by domain, and forced refresh failure produces a `Network.Refresh*Failed` log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)