### PR TITLE
Phase 15b: Firebase Crashlytics sink + Phase 15 closure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,11 @@
 #   KEY_ALIAS            — your key alias (e.g. key13)
 #   KEY_PASSWORD         — your key password
 #   NASA_API_KEY         — NASA API key for release builds
+#   GOOGLE_SERVICES_JSON_BASE64
+#                        — base64-encoded google-services.json from Firebase
+#                          Console (Phase 15b). Required for Crashlytics.
+#                          Generate: base64 -i app/google-services.json \
+#                                    | tr -d '\n' | pbcopy
 # ──────────────────────────────────────────────────────────────
 
 name: Release
@@ -145,6 +150,18 @@ jobs:
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 --decode \
             > ${{ runner.temp }}/release.jks
+
+      # ── 7b. Decode google-services.json ──────────────────────
+      #    Phase 15b — Firebase Crashlytics requires google-services.json
+      #    at app/google-services.json. Same pattern as the keystore: a
+      #    base64-encoded secret decoded into the location the build
+      #    expects. The google-services Gradle plugin reads this file at
+      #    configure time, generates per-variant resources, and the
+      #    Crashlytics SDK reads those at init.
+      - name: Decode google-services.json
+        run: |
+          echo "${{ secrets.GOOGLE_SERVICES_JSON_BASE64 }}" | base64 --decode \
+            > app/google-services.json
 
       # ── 8. Build & sign release APK ──────────────────────────
       #    Gradle reads the env vars below and applies signingConfigs.release

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,13 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+# Firebase configuration — generated per-developer / per-CI from the Firebase
+# Console. CI populates this from a GOOGLE_SERVICES_JSON_BASE64 secret; local
+# dev should download from console.firebase.google.com per the README. Never
+# commit — contains your project's API key and app IDs.
+app/google-services.json
+
 # Created by https://www.toptal.com/developers/gitignore/api/androidstudio,kotlin,macos
 # Edit at https://www.toptal.com/developers/gitignore?templates=androidstudio,kotlin,macos
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,32 @@ KEY_PASSWORD=...
 The keystore must be **PKCS12** — `signingConfigs.release.storeType` is hard-coded
 to `"PKCS12"` in `app/build.gradle`.
 
+### Firebase Crashlytics (Phase 15b)
+
+Release builds ship structured logs and crash reports to Firebase Crashlytics
+via the typed-event logging pattern documented in
+[`docs/patterns/structured-logging.md`](docs/patterns/structured-logging.md).
+The Firebase plugins are applied **conditionally** on the presence of
+`app/google-services.json`, so debug builds keep working for anyone who hasn't
+set up Firebase yet — only `assembleRelease` / `bundleRelease` / `packageRelease`
+require it (the build script fails fast if it's missing).
+
+To set up locally:
+
+1. Create a Firebase project at <https://console.firebase.google.com>.
+2. Add an Android app with package name `com.tarek.asteroidradar` (must match
+   `applicationId`).
+3. Download the generated `google-services.json` and place it at
+   `app/google-services.json`. The file is gitignored — never commit it.
+
+For CI, add the file's base64-encoded contents as the
+`GOOGLE_SERVICES_JSON_BASE64` GitHub Secret; the release workflow decodes it
+into place before building.
+
+The debug build type never wires the Crashlytics sink (`LoggerReleaseModule`
+lives in `app/src/release/`), so no Crashlytics traffic is generated during
+local development.
+
 ## Release flow
 
 Releases are tag-driven. Push a tag matching `v*` and
@@ -90,7 +116,9 @@ Releases are tag-driven. Push a tag matching `v*` and
    auto-flagged as pre-release.
 
 Required GitHub Secrets: `NASA_API_KEY`, `KEYSTORE_BASE64` (the PKCS12 keystore
-base64-encoded), `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`.
+base64-encoded), `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`,
+`GOOGLE_SERVICES_JSON_BASE64` (the Firebase config file, base64-encoded — see
+"Firebase Crashlytics" above).
 
 Tag/version conventions: SemVer with an optional classifier suffix that maps to
 a Play Store track:

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,12 +44,34 @@ plugins {
     alias(libs.plugins.kover)
 }
 
+// Phase 15b — Firebase plugins applied conditionally on `google-services.json`
+// presence. Keeps debug builds working for contributors who haven't set up
+// Firebase yet; release builds require the file (the fail-fast in the task
+// graph below produces a clearer message than the plugin's own error). The
+// plugin Maven coordinates are still on the buildscript classpath via the
+// `apply false` aliases in the root build script.
+val googleServicesJson = file("google-services.json")
+if (googleServicesJson.exists()) {
+    apply(
+        plugin =
+            libs.plugins.google.services
+                .get()
+                .pluginId,
+    )
+    apply(
+        plugin =
+            libs.plugins.firebase.crashlytics
+                .get()
+                .pluginId,
+    )
+}
+
 // Version components — bump these (not versionCode / versionName directly) when
 // cutting a release. Classifier choices: INTERNAL, ALPHA, BETA, RC, RELEASE.
 // .github/workflows/release.yml greps these names, so don't rename them.
 val versionMajor = 4
 val versionMinor = 0
-val versionPatch = 2
+val versionPatch = 3
 val versionClassifier = "INTERNAL"
 
 // versionCode formula uses minSdk as a high digit so a future minSdk bump
@@ -80,6 +102,15 @@ gradle.taskGraph.whenReady {
     if (allTasks.any { it.name in releaseTasks }) {
         require(env("NASA_API_KEY").isNotBlank()) {
             "NASA_API_KEY is required for release builds. Set it via env var or local.properties."
+        }
+        // Phase 15b — release builds need google-services.json present so the
+        // google-services plugin generates the per-variant resources Firebase
+        // Crashlytics reads at SDK init. Fail at task-graph-ready time with a
+        // pointer to the README rather than the plugin's terse default error.
+        require(googleServicesJson.exists()) {
+            "app/google-services.json is required for release builds. " +
+                "Download from console.firebase.google.com or decode " +
+                "GOOGLE_SERVICES_JSON_BASE64 via CI — see README."
         }
     }
 }
@@ -265,6 +296,18 @@ dependencies {
     // module-side declaration needed.
 
     implementation(libs.timber)
+
+    // Phase 15b — Firebase Crashlytics. Pulled with `implementation` (not
+    // `releaseImplementation`) so `CrashlyticsLogger` + `FirebaseModule`
+    // compile in both build types and unit tests in the default `src/test/`
+    // source set can construct the logger with a mocked FirebaseCrashlytics.
+    // `FirebaseCrashlytics.getInstance()` is never invoked at runtime in
+    // debug because the @IntoSet binding for CrashlyticsLogger lives in
+    // `LoggerReleaseModule` (in `app/src/release/...`), so the debug Hilt
+    // graph never asks for it. APK size impact on debug is ~1-2 MB; the
+    // release-only binding is the actual Gate 1 (build-type filtering).
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics.ktx)
 
     // Baseline profile producer. The `:benchmark` module generates
     // `baseline-prof.txt` via its `StartupBaselineProfile`; AGP wires the

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -307,7 +307,7 @@ dependencies {
     // graph never asks for it. APK size impact on debug is ~1-2 MB; the
     // release-only binding is the actual Gate 1 (build-type filtering).
     implementation(platform(libs.firebase.bom))
-    implementation(libs.firebase.crashlytics.ktx)
+    implementation(libs.firebase.crashlytics.sdk)
 
     // Baseline profile producer. The `:benchmark` module generates
     // `baseline-prof.txt` via its `StartupBaselineProfile`; AGP wires the

--- a/app/src/main/java/com/tarek/asteroidradar/di/FirebaseModule.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/di/FirebaseModule.kt
@@ -1,0 +1,49 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.di
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+// Provides the `FirebaseCrashlytics` singleton for constructor injection into
+// `CrashlyticsLogger`. Stays in main (not release-only) so Hilt's graph check
+// is happy for both build types; the actual `FirebaseCrashlytics.getInstance()`
+// call is only ever invoked when `LoggerReleaseModule` binds CrashlyticsLogger
+// into the Logger set — which only happens in release builds.
+@Module
+@InstallIn(SingletonComponent::class)
+object FirebaseModule {
+    @Provides
+    @Singleton
+    fun provideFirebaseCrashlytics(): FirebaseCrashlytics = FirebaseCrashlytics.getInstance()
+}

--- a/app/src/main/java/com/tarek/asteroidradar/log/CrashlyticsLogger.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/log/CrashlyticsLogger.kt
@@ -1,0 +1,78 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.log
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import javax.inject.Inject
+import javax.inject.Singleton
+
+// The Firebase Crashlytics sink (Phase 15b). Bound into `Set<Logger>` only
+// in release builds via `LoggerReleaseModule` (Gate 1 — build-type filtering);
+// debug builds never reach this code path.
+//
+// Severity mapping (Gate 2 — filter floor):
+//  - Below `LogPriority.Warn` (Verbose / Debug / Info): drop entirely.
+//    Keeps chatter out of Crashlytics's per-session non-fatal cap
+//    (~8/session) and 64 KB breadcrumb buffer.
+//  - Warn: `Crashlytics.log(...)` breadcrumb. Attached to the next crash
+//    or non-fatal report from this session.
+//  - Error with throwable: `recordException(...)` (counts as a non-fatal)
+//    plus a breadcrumb capturing the rendered tag/message.
+//
+// Attributes flow to `setCustomKey` so each pair is indexed as a searchable
+// field on the next crash. `setCustomKey` accepts the six primitives below
+// natively; anything else gets stringified so the call still succeeds.
+@Singleton
+class CrashlyticsLogger
+    @Inject
+    constructor(
+        private val crashlytics: FirebaseCrashlytics,
+    ) : Logger {
+        override fun log(event: LogEvent) {
+            if (event.priority < LogPriority.Warn) return
+
+            event.attributes.forEach { (key, value) ->
+                when (value) {
+                    is String -> crashlytics.setCustomKey(key, value)
+                    is Int -> crashlytics.setCustomKey(key, value)
+                    is Long -> crashlytics.setCustomKey(key, value)
+                    is Float -> crashlytics.setCustomKey(key, value)
+                    is Double -> crashlytics.setCustomKey(key, value)
+                    is Boolean -> crashlytics.setCustomKey(key, value)
+                    else -> crashlytics.setCustomKey(key, value.toString())
+                }
+            }
+
+            val line = "[${event.tag}] ${event.message}"
+            crashlytics.log(line)
+            if (event.priority == LogPriority.Error) {
+                event.throwable?.let { crashlytics.recordException(it) }
+            }
+        }
+    }

--- a/app/src/release/java/com/tarek/asteroidradar/di/LoggerReleaseModule.kt
+++ b/app/src/release/java/com/tarek/asteroidradar/di/LoggerReleaseModule.kt
@@ -1,0 +1,54 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.di
+
+import com.tarek.asteroidradar.log.CrashlyticsLogger
+import com.tarek.asteroidradar.log.Logger
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+
+// Phase 15b — Gate 1 (build-type filtering). This module only lives in the
+// `release/` source set, so AGP's source-set merging means Hilt only sees it
+// in release builds. The debug Hilt graph keeps the Logger set at just
+// TimberLogger (bound in the shared `LoggerModule`); the release Hilt graph
+// adds CrashlyticsLogger via the `@IntoSet` contribution below.
+//
+// No call-site change is required when this module appears — `CompositeLogger`
+// injects `Set<@JvmSuppressWildcards Logger>` and iterates whatever the Hilt
+// graph supplies for the active build type.
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class LoggerReleaseModule {
+    @Binds
+    @IntoSet
+    abstract fun bindsCrashlyticsLoggerIntoSet(impl: CrashlyticsLogger): Logger
+}

--- a/app/src/test/java/com/tarek/asteroidradar/log/CrashlyticsLoggerTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/log/CrashlyticsLoggerTest.kt
@@ -1,0 +1,98 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.log
+
+import com.google.firebase.crashlytics.FirebaseCrashlytics
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+// Concrete LogEvent subtypes only: same constraint as TimberLoggerTest
+// (sealed-class hierarchies can't be extended from the unit-test source set —
+// Kotlin treats it as a different module). The `Error` priority `when` arm
+// is therefore not covered here — no concrete event uses it yet. The mapping
+// is trivial and will be covered organically the first time an Error event
+// lands.
+class CrashlyticsLoggerTest {
+    private lateinit var crashlytics: FirebaseCrashlytics
+    private lateinit var logger: CrashlyticsLogger
+
+    @Before
+    fun setUp() {
+        crashlytics = mockk(relaxed = true)
+        logger = CrashlyticsLogger(crashlytics)
+    }
+
+    @Test
+    fun `Info-level events are dropped (severity floor at Warn)`() {
+        logger.log(LogEvent.App.Launched)
+
+        verify(exactly = 0) { crashlytics.log(any()) }
+        verify(exactly = 0) { crashlytics.recordException(any()) }
+        verify(exactly = 0) { crashlytics.setCustomKey(any(), any<String>()) }
+    }
+
+    @Test
+    fun `Warn events emit a breadcrumb via log()`() {
+        logger.log(LogEvent.Network.RefreshAsteroidsFailed(IOException("network down")))
+
+        verify { crashlytics.log("[Network] refreshAsteroids() failed") }
+    }
+
+    @Test
+    fun `Warn events do not call recordException`() {
+        logger.log(LogEvent.Network.RefreshAsteroidsFailed(IOException("network down")))
+
+        verify(exactly = 0) { crashlytics.recordException(any()) }
+    }
+
+    @Test
+    fun `Warn events with attributes call setCustomKey for each typed value`() {
+        logger.log(
+            LogEvent.Work.RefreshDataWorkerFinished(
+                durationMs = 1234L,
+                outcome = LogEvent.Work.Outcome.Failure,
+            ),
+        )
+
+        // `outcome` arrives as String, `durationMs` as Long — the when block
+        // in CrashlyticsLogger routes each to the matching setCustomKey overload.
+        verify { crashlytics.setCustomKey("outcome", "Failure") }
+        verify { crashlytics.setCustomKey("durationMs", 1234L) }
+    }
+
+    @Test
+    fun `tag is wrapped in brackets and prepended to the message`() {
+        logger.log(LogEvent.Network.RefreshPictureOfDayFailed(IOException("dns fail")))
+
+        verify { crashlytics.log("[Network] refreshPictureOfDay() failed") }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,12 @@ buildscript {
 plugins {
     alias(libs.plugins.android.application) apply false
     alias(libs.plugins.detekt) apply false
+    // Firebase Crashlytics + Google Services plugins — Phase 15b. Registered
+    // here `apply false` so app/build.gradle.kts can apply them conditionally
+    // (only when `app/google-services.json` exists); the plugin classpath
+    // resolution still has to happen at the root.
+    alias(libs.plugins.firebase.crashlytics) apply false
+    alias(libs.plugins.google.services) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
     alias(libs.plugins.kotlin.serialization) apply false

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -32,8 +32,8 @@ shippable; pick them off in order — each one stacks on the last.
 | 14a | `:benchmark` module + `StartupBenchmark` | Done (#132) — first second-module in the project. AndroidX Macrobenchmark library on AGP-9-compatible `androidx.baselineprofile 1.5.0-alpha06`. |
 | 14b | `BaselineProfileGenerator` + checked-in `baseline-prof.txt` | Done (#133) — 20.7k-entry profile generated on Pixel 7 / API 33 emulator; bundles into AAB at `BUNDLE-METADATA/com.android.tools.build.profiles/baseline.prof`. Bumps to **`v4.0.2-INTERNAL`** (tag bundled with 14c). |
 | 14c | CI workflow + GMD provisioning | Done (#134) — manual `workflow_dispatch` only; provisions Pixel 7 / API 34 GMD; uploads Perfetto traces as artifacts. Closes issue #131. |
-| 15a | Logging architecture (sealed events + Logger interface + TimberLogger sink) | In progress (#151) — sealed `LogEvent` hierarchy + `Logger` interface + `CompositeLogger` fanout via Hilt `@IntoSet`. Migrates 4 existing `Timber.d` call sites and adds 2 `RefreshDataWorker` lifecycle events. Reference doc at `docs/patterns/structured-logging.md`. Part of umbrella #150. |
-| 15b | Firebase Crashlytics sink | Queued — adds `CrashlyticsLogger` as a second `@IntoSet` binding. Wires Firebase setup + `google-services.json`. Bumps to **`v4.0.3-INTERNAL`** when it lands. Part of umbrella #150. |
+| 15a | Logging architecture (sealed events + Logger interface + TimberLogger sink) | Done (#152) — sealed `LogEvent` hierarchy + `Logger` interface + `CompositeLogger` fanout via Hilt `@IntoSet`. Migrated 4 existing `Timber.d` call sites and added 2 `RefreshDataWorker` lifecycle events. Reference doc at `docs/patterns/structured-logging.md`. |
+| 15b | Firebase Crashlytics sink | Done — `CrashlyticsLogger` bound into `Set<Logger>` only in release builds via `LoggerReleaseModule` (Gate 1, build-type filtering). Severity floor at Warn inside the sink (Gate 2) keeps Crashlytics within its per-session non-fatal cap. Adds Firebase BoM + Crashlytics SDK + plugins; `google-services.json` required for release builds (gitignored; CI decodes from `GOOGLE_SERVICES_JSON_BASE64`). Bumps to **`v4.0.3-INTERNAL`**. Closes umbrella #150. |
 | — | **Module split** lands with feature #2, not as a phase | — |
 
 Tick the table when phases land. Each phase below lists scope, rationale, and
@@ -42,18 +42,18 @@ the rough size; sub-bullets are the concrete deltas.
 ## Current shipping state
 
 Snapshot for whoever opens this repo next (likely future-you). Reflects the
-state at 2026-05-18, after Phase 14 closed end-to-end (`v4.0.2-INTERNAL`
-tagged 2026-05-08, bundling 14a/b/c into a single cut).
+state at 2026-05-18, after Phase 15 closed end-to-end with `v4.0.3-INTERNAL`
+bundling 15a (logging architecture) + 15b (Crashlytics sink) into one tag.
 
 - **Live on Play Internal**: `v3.0.4-INTERNAL` — bundles Phase 12 + DI
   cleanup + NDK symbols + APOD video-day handling. User confirmed it
   behaves correctly on a Pixel 7 Pro 2026-05-08.
-- **Version-of-record on `master`**: `v4.0.2-INTERNAL` — Phase 14
-  (baseline profiles + macrobenchmark). Four consecutive smoke-skips this
-  cycle (`v3.0.3`, `v4.0.0`, `v4.0.1`, `v4.0.2`) — all explicit one-offs,
-  not new policy. The pre-tag protocol in the operating principles still
-  says install on a real device before any future `v*` tag; if the
-  pattern continues past `v5.0`, fold it into the principles section.
+- **Version-of-record on `master`**: `v4.0.3-INTERNAL` — Phase 15
+  (structured logging + Crashlytics). The streak of four consecutive
+  smoke-skips (`v3.0.3`, `v4.0.0`, `v4.0.1`, `v4.0.2`) ended with 15a's
+  on-emulator smoke (typed events + worker lifecycle verified on AVD).
+  `v4.0.3` adds the Crashlytics sink — release-build install + force-crash
+  smoke is the appropriate pre-tag check before pushing the tag.
 - **v3.x → v4.0 release timeline** (chronological):
   - `v3.0.0-INTERNAL` — Phase 9c Compose rewrite. **Broken on real devices**
     via release-only converter-factory regression. Never roll back to.
@@ -79,8 +79,20 @@ tagged 2026-05-08, bundling 14a/b/c into a single cut).
     Tagged 2026-05-08 (workflow run `25583579445`); smoke skipped (the
     fourth in the streak — benchmark module + macrobenchmark workflow
     are dev-tooling-only, never ship to users).
+  - `v4.0.3-INTERNAL` — Phase 15 (#152 + 15b PR). Structured logging
+    pattern: sealed `LogEvent` taxonomy + Hilt set-multibinding fanout
+    (15a, on-AVD smoke verified on Pixel 7 Pro / API 33), then Firebase
+    Crashlytics sink as a second `@IntoSet` binding scoped to release
+    builds via source-set Hilt module (15b, Gate 1 build-type filter +
+    Gate 2 severity floor at Warn). Educational reference doc at
+    `docs/patterns/structured-logging.md`. Tag held pending release-build
+    smoke on a real device (force-crash → confirm Crashlytics receives
+    it within ~5 min).
 - **Next pickup**: queue empty. Pickup is from the "Quality bets" parking
-  lot (capped at 3) or fresh feature work.
+  lot (capped at 3) or fresh feature work. Possible 15c-shaped follow-ups
+  (NavController route tracking, tag-as-event-id restructure,
+  decorator-based runtime filtering, double-swallow cleanup) were
+  explicitly deferred — promote via a fresh issue if any becomes timely.
 
 ### Issue close-keyword lesson (2026-05-08)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,11 +70,14 @@ timber = "5.0.1"
 # Firebase BoM aligns every firebase-* artifact to one tested-together release.
 # Phase 15b only pulls Crashlytics; the BoM keeps the door open for future
 # Firebase additions (Performance, Remote Config) without per-artifact pinning.
-firebaseBom = "33.7.0"
+# Bumped to 34.13.0 per Firebase Console's setup guidance; the BoM 34 series
+# also folds Kotlin extensions back into the main `firebase-crashlytics`
+# artifact, so the legacy `-ktx` suffix is dropped on the library coord below.
+firebaseBom = "34.13.0"
 # Google Services Gradle plugin parses `app/google-services.json` and generates
 # the per-build-type `google-services.xml` resource that Firebase libs read at
 # init. Plugin version-tracks the Firebase Android client release line.
-googleServices = "4.4.2"
+googleServices = "4.4.4"
 # Firebase Crashlytics Gradle plugin — uploads ProGuard / R8 mapping files +
 # generates the BuildConfig flag the SDK uses to detect minification.
 firebaseCrashlyticsPlugin = "3.0.2"
@@ -150,12 +153,14 @@ retrofit-converter-scalars = { module = "com.squareup.retrofit2:converter-scalar
 
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
 # Firebase BoM platform — applied via `platform(...)` so the firebase-* deps
-# below can drop their version refs. Phase 15b imports it only on the release
-# classpath via `releaseImplementation`.
+# below can drop their version refs.
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
-# Crashlytics KTX SDK — Kotlin-idiomatic extensions over firebase-crashlytics.
-# Version managed by the BoM; no version.ref here.
-firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-ktx" }
+# Crashlytics SDK. The `-ktx` suffix was deprecated in BoM 34 — Kotlin
+# extensions are now folded into the main artifact. Catalog key is
+# `firebase-crashlytics-sdk` (not `firebase-crashlytics`) to keep a distinct
+# accessor from the `firebase-crashlytics` plugin entry below — same pattern
+# as `hilt-android` (library) coexisting with `hilt` (plugin).
+firebase-crashlytics-sdk = { module = "com.google.firebase:firebase-crashlytics" }
 # coil-video registers a VideoFrameDecoder.Factory that pulls frame 0 out
 # of any direct .mp4/.webm URL Coil downloads — covers NASA APOD video days
 # (#123). The ImageLoader the app provides via NetworkModule installs the

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -67,6 +67,18 @@ hilt = "2.59.2"
 retrofit = "3.0.0"
 timber = "5.0.1"
 
+# Firebase BoM aligns every firebase-* artifact to one tested-together release.
+# Phase 15b only pulls Crashlytics; the BoM keeps the door open for future
+# Firebase additions (Performance, Remote Config) without per-artifact pinning.
+firebaseBom = "33.7.0"
+# Google Services Gradle plugin parses `app/google-services.json` and generates
+# the per-build-type `google-services.xml` resource that Firebase libs read at
+# init. Plugin version-tracks the Firebase Android client release line.
+googleServices = "4.4.2"
+# Firebase Crashlytics Gradle plugin — uploads ProGuard / R8 mapping files +
+# generates the BuildConfig flag the SDK uses to detect minification.
+firebaseCrashlyticsPlugin = "3.0.2"
+
 androidxTestExtJunit = "1.3.0"
 junit = "4.13.2"
 mockk = "1.14.9"
@@ -137,6 +149,13 @@ retrofit-converter-kotlinx-serialization = { module = "com.squareup.retrofit2:co
 retrofit-converter-scalars = { module = "com.squareup.retrofit2:converter-scalars", version.ref = "retrofit" }
 
 coil-compose = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+# Firebase BoM platform — applied via `platform(...)` so the firebase-* deps
+# below can drop their version refs. Phase 15b imports it only on the release
+# classpath via `releaseImplementation`.
+firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
+# Crashlytics KTX SDK — Kotlin-idiomatic extensions over firebase-crashlytics.
+# Version managed by the BoM; no version.ref here.
+firebase-crashlytics-ktx = { module = "com.google.firebase:firebase-crashlytics-ktx" }
 # coil-video registers a VideoFrameDecoder.Factory that pulls frame 0 out
 # of any direct .mp4/.webm URL Coil downloads — covers NASA APOD video days
 # (#123). The ImageLoader the app provides via NetworkModule installs the
@@ -252,6 +271,12 @@ kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref =
 # the @Serializable Asteroid that Nav-Compose typed routes encode.
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+# Google Services Gradle plugin (Phase 15b). Applied conditionally in
+# `app/build.gradle.kts` — only when `app/google-services.json` exists so debug
+# builds without a Firebase setup still configure cleanly. Required for any
+# firebase-* SDK at runtime (parses JSON → generates per-variant resources).
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 # Kover (Kotlin coverage). Generates HTML reports under app/build/reports/kover/html.
 # No coverage gate yet — `koverVerify` lands once Phase 7b/7c add real tests.


### PR DESCRIPTION
## Summary

Adds the second `@IntoSet` binding to the Phase 15a logging fanout — `CrashlyticsLogger` routes events to Firebase Crashlytics. Cost-gates applied as designed:

- **Gate 1 — build-type filtering.** `LoggerReleaseModule` lives in `app/src/release/...`, so AGP's source-set merging means Hilt only sees the `@IntoSet` binding for `CrashlyticsLogger` in release builds. Debug builds keep the Logger set at just `TimberLogger`. **No call-site change** — `CompositeLogger` iterates whatever the active variant supplies.
- **Gate 2 — severity floor at Warn.** `CrashlyticsLogger.log()` short-circuits events below `LogPriority.Warn`. Keeps Verbose/Debug/Info chatter out of Crashlytics's per-session non-fatal cap (~8/session) and 64 KB breadcrumb buffer.

Closes #150 (umbrella issue).

## Sink mapping

| `LogPriority` | Crashlytics action |
|---|---|
| Verbose / Debug / Info | dropped (Gate 2) |
| Warn | `Crashlytics.log()` breadcrumb + `setCustomKey` for each attribute |
| Error + throwable | `recordException(throwable)` + breadcrumb + custom keys |

Attributes flow through a `when` block that picks the matching `setCustomKey` overload for primitives (`String` / `Int` / `Long` / `Float` / `Double` / `Boolean`) and falls back to `toString()` for anything else.

## Source-set layout

| File | Source set | Why |
|---|---|---|
| `log/CrashlyticsLogger.kt` | `main/` | So unit tests in default `src/test/` can construct with a mocked `FirebaseCrashlytics` |
| `di/FirebaseModule.kt` | `main/` | Provides `FirebaseCrashlytics` for Hilt graph in both build types — but never invoked at runtime in debug (no consumer asks for it) |
| `di/LoggerReleaseModule.kt` | `release/` | **The actual build-type gate.** Only release builds see this `@IntoSet` binding |

Debug builds compile the Firebase SDK (~1-2 MB APK bloat) but never call `FirebaseCrashlytics.getInstance()` — the trade-off keeps tests in the default test source set instead of `testRelease`.

## Setup required

`app/google-services.json` is gitignored and required for release builds. Two paths:

- **Local**: download from <https://console.firebase.google.com> (Android app, package `com.tarek.asteroidradar`), drop into `app/`.
- **CI**: new `GOOGLE_SERVICES_JSON_BASE64` GitHub Secret — release workflow decodes it before the build.

Debug builds work without this file (conditional plugin application + Gate 1 means no Firebase code runs in debug).

Documented end-to-end in README and `.github/workflows/release.yml`'s header comment.

## Version

Bumps `versionPatch` 2 → 3 (`v4.0.3-INTERNAL`). Tag held until release-build device smoke per the pre-tag protocol. Phase 15 ships as one tag covering 15a + 15b, same one-tag-per-phase pattern as Phase 14.

## Test plan

- [x] `./gradlew spotlessCheck detekt :app:testDebugUnitTest` — green.
- [x] `./gradlew assembleDebug` — green.
- [x] `./gradlew lintRelease` — green (no new errors; only pre-existing baseline warnings).
- [x] `./gradlew buildHealth` — one pre-existing advisory on `androidx.hilt.navigation.compose` unrelated to this PR.
- [ ] `./gradlew assembleRelease` — not runnable locally (requires real `google-services.json`). CI will run it with the decoded secret.
- [ ] On-device release smoke: install signed release APK, kill wifi, relaunch → wait ~5 min → confirm `Network.Refresh*Failed` breadcrumbs appear in Firebase Console → Crashlytics → Issues. (No `Error`-priority event ships yet, so `recordException` won't fire on this PR; the breadcrumb path is the live one.)

## Phase 15 closure (bundled here)

- `docs/IMPROVEMENT_PLAN.md`: rows for 15a + 15b flip to Done; `v4.0.3-INTERNAL` joins the release timeline; "next pickup" resets to "queue empty"; deferred 15c-shaped follow-ups called out.
- Umbrella issue #150 closed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)