### PR TITLE
fix: bump OkHttp connect/read timeouts to 20s for APOD reliability

### DIFF
--- a/app/src/main/java/com/tarek/asteroidradar/di/NetworkModule.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/di/NetworkModule.kt
@@ -40,10 +40,18 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.serialization.json.Json
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.kotlinx.serialization.asConverterFactory
 import retrofit2.converter.scalars.ScalarsConverterFactory
+import java.time.Duration
 import javax.inject.Singleton
+
+// Issue #166: OkHttp's 10s default connect/read timeout was firing on APOD
+// fetches when api.nasa.gov was slow (3–5s responses on degraded days). Bumped
+// to 20s so flaky-but-reachable responses land in Room instead of failing into
+// the cache-less broken-image path.
+private val NETWORK_TIMEOUT: Duration = Duration.ofSeconds(20)
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -56,6 +64,15 @@ object NetworkModule {
     @Singleton
     fun provideJson(): Json = Json { ignoreUnknownKeys = true }
 
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient =
+        OkHttpClient
+            .Builder()
+            .connectTimeout(NETWORK_TIMEOUT)
+            .readTimeout(NETWORK_TIMEOUT)
+            .build()
+
     // Builder order matters: Scalars first matches `String` returns and yields
     // the raw response body (for `getAsteroids`, where the parser walks the
     // nested-by-date payload manually); kotlinx-serialization second handles
@@ -64,10 +81,14 @@ object NetworkModule {
     // reflection-free at runtime.
     @Provides
     @Singleton
-    fun provideRetrofit(json: Json): Retrofit =
+    fun provideRetrofit(
+        client: OkHttpClient,
+        json: Json,
+    ): Retrofit =
         Retrofit
             .Builder()
             .baseUrl(Constants.BASE_URL)
+            .client(client)
             .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
             .build()

--- a/app/src/test/java/com/tarek/asteroidradar/di/NetworkModuleTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/di/NetworkModuleTest.kt
@@ -1,0 +1,73 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.di
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import okhttp3.OkHttpClient
+import org.junit.Test
+import java.time.Duration
+
+private val TIMEOUT_20S_MS = Duration.ofSeconds(20).toMillis().toInt()
+
+class NetworkModuleTest {
+    @Test
+    fun `provideOkHttpClient sets a 20-second connect timeout`() {
+        // Given the module's OkHttp provider
+        // When invoked
+        val client = NetworkModule.provideOkHttpClient()
+
+        // Then the connect timeout is 20 seconds (issue #166 — was 10s default)
+        assertThat(client.connectTimeoutMillis).isEqualTo(TIMEOUT_20S_MS)
+    }
+
+    @Test
+    fun `provideOkHttpClient sets a 20-second read timeout`() {
+        // Given the module's OkHttp provider
+        // When invoked
+        val client = NetworkModule.provideOkHttpClient()
+
+        // Then the read timeout is 20 seconds — covers NASA APOD's 3–5s+ responses
+        // on degraded days that previously tripped the 10s default
+        assertThat(client.readTimeoutMillis).isEqualTo(TIMEOUT_20S_MS)
+    }
+
+    @Test
+    fun `provideRetrofit uses the provided OkHttp client`() {
+        // Given a sentinel OkHttp client (distinct from the module's default)
+        val sentinel = OkHttpClient.Builder().build()
+
+        // When Retrofit is constructed via the module
+        val retrofit = NetworkModule.provideRetrofit(sentinel, Json)
+
+        // Then Retrofit's callFactory is the same sentinel instance — proves the
+        // 20s-timeout client actually reaches the wire, no parallel default client
+        assertThat(retrofit.callFactory()).isSameInstanceAs(sentinel)
+    }
+}


### PR DESCRIPTION
## Summary

- Add `provideOkHttpClient()` to `NetworkModule` with 20s connect + 20s read timeouts; thread into the Retrofit builder via Hilt.
- Three unit tests in `NetworkModuleTest` (style C, backtick + G/W/T) cover the new client timeouts and the wire-through to Retrofit.

## Why

OkHttp's 10s default was firing on APOD fetches when `api.nasa.gov` was slow (verified today: 3–5s responses with occasional 503s). Combined with no cached row, the UI shows the broken-image icon — visible regression on the v3.0.4-INTERNAL Play build.

Pre-fix emulator trace at master HEAD:
```
05-31 14:12:36 W Network: refreshPictureOfDay() failed cause=timeout
05-31 14:12:36 W Network: java.net.SocketTimeoutException: timeout
```
12s after launch. Post-fix: no failure event, image renders ("Pillars of Creation, Eagle Nebula").

## Test plan

- [x] `./gradlew :app:testDebugUnitTest --tests "*NetworkModuleTest*"` — 3/3 green
- [x] `./gradlew spotlessCheck detekt test assembleDebug` — clean
- [x] `./gradlew lintRelease` — clean (note: 67 stale baseline entries surfaced as "perhaps they have been fixed?" — unrelated to this PR; baseline regen is queued separately)
- [x] `./gradlew :app:assembleRelease` — clean
- [x] On emulator-5554: uninstall prior → install release APK → cold launch → APOD image renders within 20s window, no `Network.RefreshPictureOfDayFailed` event in logcat
- [x] Screenshot verified visually

Fixes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)