### PR TITLE
fix(ui): render placeholder when APOD cache is empty, not broken icon

### DIFF
--- a/app/src/androidTest/java/com/tarek/asteroidradar/ui/main/MainScreenTest.kt
+++ b/app/src/androidTest/java/com/tarek/asteroidradar/ui/main/MainScreenTest.kt
@@ -36,7 +36,9 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.test.espresso.intent.Intents
@@ -74,6 +76,15 @@ class MainScreenTest {
             url = "file:///does/not/exist.mp4",
         )
 
+    // Same trick — file:// URL forces Coil's error path for an image-day, so the
+    // broken-icon path composes deterministically without a network round-trip.
+    private val brokenImageDayPicture =
+        PictureOfDay(
+            mediaType = "image",
+            title = "Definitely Not a Real Image",
+            url = "file:///does/not/exist.jpg",
+        )
+
     @Before
     fun setUp() {
         Intents.init()
@@ -87,6 +98,41 @@ class MainScreenTest {
     @After
     fun tearDown() {
         Intents.release()
+    }
+
+    @Test
+    fun nullPictureShowsPlaceholderNotBrokenIcon() {
+        // Given the cache is empty (fresh install, no APOD row in Room yet)
+        composeTestRule.setContent {
+            ImageOfTheDayHeader(picture = null, onVideoTap = {})
+        }
+
+        // When the header composes
+        // Then the placeholder testTag is on screen and the broken-icon testTag is not
+        // (issue #168: cache-empty state must not surface as a load-failure)
+        composeTestRule.onNodeWithTag(APOD_PLACEHOLDER_TEST_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(APOD_BROKEN_ICON_TEST_TAG).assertDoesNotExist()
+    }
+
+    @Test
+    fun nonNullPictureWithBadUrlShowsBrokenIconNotPlaceholder() {
+        // Given a cached image-day picture with an unreachable URL
+        composeTestRule.setContent {
+            ImageOfTheDayHeader(picture = brokenImageDayPicture, onVideoTap = {})
+        }
+
+        // When Coil's error slot fires (deterministic via file:// scheme)
+        composeTestRule.waitUntil(timeoutMillis = LOAD_TIMEOUT_MS) {
+            composeTestRule
+                .onAllNodesWithTag(APOD_BROKEN_ICON_TEST_TAG)
+                .fetchSemanticsNodes()
+                .isNotEmpty()
+        }
+
+        // Then the broken-icon testTag is on screen and the placeholder testTag is not —
+        // preserves the load-failure surface for actual broken URLs
+        composeTestRule.onNodeWithTag(APOD_BROKEN_ICON_TEST_TAG).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(APOD_PLACEHOLDER_TEST_TAG).assertDoesNotExist()
     }
 
     @Test

--- a/app/src/main/java/com/tarek/asteroidradar/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/ui/main/MainScreen.kt
@@ -62,6 +62,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -77,6 +78,12 @@ import com.tarek.asteroidradar.domain.PictureOfDay
 import com.tarek.asteroidradar.repository.AsteroidRepository.AsteroidsFilter
 
 private val ApodHeaderHeight = 220.dp
+
+// Issue #168: test seams to distinguish the cache-empty placeholder render from
+// the load-failure broken-icon render. The two paths previously looked identical
+// to instrumentation tests.
+internal const val APOD_PLACEHOLDER_TEST_TAG = "apod-placeholder"
+internal const val APOD_BROKEN_ICON_TEST_TAG = "apod-broken-icon"
 
 // Compose port of fragment_main.xml + main_overflow_menu.xml (Phase 9c). The
 // top-app-bar's overflow menu replaces the AppCompat MenuProvider; the
@@ -181,36 +188,55 @@ internal fun ImageOfTheDayHeader(
                 .fillMaxWidth()
                 .height(ApodHeaderHeight),
     ) {
-        SubcomposeAsyncImage(
-            model =
-                ImageRequest
-                    .Builder(context)
-                    .data(picture?.url?.replaceFirst(Regex("^http://"), "https://"))
-                    .placeholder(R.drawable.placeholder_picture_of_day)
-                    .crossfade(true)
-                    .build(),
-            contentDescription = stringResource(R.string.image_of_the_day),
-            contentScale = ContentScale.Crop,
-            modifier = Modifier.fillMaxSize(),
-            error = {
-                // VideoFrameDecoder handles direct .mp4/.webm — when it can't
-                // (YouTube/Vimeo embeds), fall back to a tap-through card
-                // instead of a broken-image icon.
-                if (picture?.mediaType == "video") {
-                    VideoFallbackCard(
-                        title = picture.title,
-                        onClick = { onVideoTap(picture.url) },
-                    )
-                } else {
-                    Icon(
-                        painter = painterResource(R.drawable.ic_broken_image),
-                        contentDescription = null,
-                        tint = Color.Unspecified,
-                        modifier = Modifier.fillMaxSize(),
-                    )
-                }
-            },
-        )
+        if (picture == null) {
+            // Cache is empty (fresh install, or no refresh has landed yet). Paint
+            // the placeholder color while the background refresh works — distinct
+            // from the "load failed" path so a slow first network round-trip
+            // doesn't surface as a broken-image icon (issue #168). Compose's
+            // painterResource() rejects <shape> drawables, so we use the same
+            // hex as the legacy drawable via colorResource + Modifier.background.
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(colorResource(R.color.placeholder_picture_of_day))
+                        .testTag(APOD_PLACEHOLDER_TEST_TAG),
+            )
+        } else {
+            SubcomposeAsyncImage(
+                model =
+                    ImageRequest
+                        .Builder(context)
+                        .data(picture.url.replaceFirst(Regex("^http://"), "https://"))
+                        .placeholder(R.drawable.placeholder_picture_of_day)
+                        .crossfade(true)
+                        .build(),
+                contentDescription = stringResource(R.string.image_of_the_day),
+                contentScale = ContentScale.Crop,
+                modifier = Modifier.fillMaxSize(),
+                error = {
+                    // VideoFrameDecoder handles direct .mp4/.webm — when it can't
+                    // (YouTube/Vimeo embeds), fall back to a tap-through card
+                    // instead of a broken-image icon.
+                    if (picture.mediaType == "video") {
+                        VideoFallbackCard(
+                            title = picture.title,
+                            onClick = { onVideoTap(picture.url) },
+                        )
+                    } else {
+                        Icon(
+                            painter = painterResource(R.drawable.ic_broken_image),
+                            contentDescription = null,
+                            tint = Color.Unspecified,
+                            modifier =
+                                Modifier
+                                    .fillMaxSize()
+                                    .testTag(APOD_BROKEN_ICON_TEST_TAG),
+                        )
+                    }
+                },
+            )
+        }
         // Caption stays visible on image-days; on video-days the card paints
         // over it via the error slot's fillMaxSize, so no double-label.
         if (!isVideo) {

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -42,5 +42,10 @@
     <!-- 33% black scrim under the APOD caption text — preserves legibility
          over light NASA imagery. Mirrors fragment_main.xml's "#55010613". -->
     <color name="image_of_day_caption_scrim">#55010613</color>
+    <!-- Flat fill used while the APOD cache is empty (issue #168). Same hex as
+         the legacy `placeholder_picture_of_day.xml` shape drawable — Compose's
+         painterResource() doesn't render <shape>, so we paint the rectangle
+         via Modifier.background() instead. -->
+    <color name="placeholder_picture_of_day">#ECF0F1</color>
 
 </resources>


### PR DESCRIPTION
## Summary

- `ImageOfTheDayHeader` short-circuits to a colored `Box` when `picture == null`, instead of falling through to `SubcomposeAsyncImage(data = null)` (which rendered the broken-image icon).
- Two new `testTag` constants (`APOD_PLACEHOLDER_TEST_TAG`, `APOD_BROKEN_ICON_TEST_TAG`) so instrumented tests can distinguish the cache-empty render from the load-failure render.
- Two new instrumented tests in `MainScreenTest` cover the null-picture and non-null-with-bad-URL paths.
- New `placeholder_picture_of_day` color in `colors.xml` (`#ECF0F1` — same hex as the legacy shape drawable). Compose's `painterResource()` rejects `<shape>` drawables, so the new branch paints via `Modifier.background()` instead.

## Why

Companion to #166. Even with the 20s OkHttp timeout, the first cold launch on a fresh install hits a brief window where the cache is empty and the refresh is in flight. Without this fix the user sees the broken-icon — the exact UI seen on the v3.0.4-INTERNAL Pixel 7 Pro on 2026-05-31. Phase 12's "cached row paints immediately" promise only holds when the cache is non-empty; this PR closes the gap.

## Test plan

- [x] `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.tarek.asteroidradar.ui.main.MainScreenTest` — 5/5 green on emulator-5554 (2 new + 3 existing)
- [x] `./gradlew spotlessCheck detekt lintRelease test assembleDebug assembleRelease` — clean
- [x] On emulator-5554 (release APK, wifi-off, fresh uninstall+install): cold launch now renders the gray placeholder behind the "Image of the Day" caption, not the broken-image icon
- [x] Screenshot verified visually

Fixes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)