### PR TITLE
chore: bump version to v4.0.4-INTERNAL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,7 +71,7 @@ if (googleServicesJson.exists()) {
 // .github/workflows/release.yml greps these names, so don't rename them.
 val versionMajor = 4
 val versionMinor = 0
-val versionPatch = 3
+val versionPatch = 4
 val versionClassifier = "INTERNAL"
 
 // versionCode formula uses minSdk as a high digit so a future minSdk bump


### PR DESCRIPTION
## Summary

Patch bump for two APOD reliability fixes already on master:
- #167 — OkHttp connect/read timeouts 10s → 20s
- #169 — render placeholder when APOD cache is empty (no broken-icon)

`versionPatch` 3 → 4. No other changes. Once merged, tag `v4.0.4-INTERNAL` at the merge commit to trigger the release workflow.