### PR TITLE
fix(work): refresh the APOD in the daily worker, not just on cold start

### DIFF
--- a/app/src/main/java/com/tarek/asteroidradar/work/RefreshDataWorker.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/work/RefreshDataWorker.kt
@@ -71,6 +71,14 @@ class RefreshDataWorker
                 try {
                     repository.deletePastAsteroids()
                     repository.refreshAsteroids()
+                    // Issue #176: keep the APOD current on the daily cadence too.
+                    // MainViewModel.init is the only other caller and fires just
+                    // on cold start, so a long-lived process would otherwise leave
+                    // yesterday's picture cached in Room. refreshPictureOfDay()
+                    // swallows its own network failures (logged as
+                    // RefreshPictureOfDayFailed), so it never trips the
+                    // asteroid-driven HttpException retry below.
+                    repository.refreshPictureOfDay()
                     outcome = LogEvent.Work.Outcome.Success
                     Result.success()
                 } catch (e: HttpException) {

--- a/app/src/test/java/com/tarek/asteroidradar/work/RefreshDataWorkerTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/work/RefreshDataWorkerTest.kt
@@ -1,0 +1,110 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.work
+
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import com.google.common.truth.Truth.assertThat
+import com.tarek.asteroidradar.log.Logger
+import com.tarek.asteroidradar.repository.AsteroidRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import retrofit2.HttpException
+
+class RefreshDataWorkerTest {
+    private lateinit var repository: AsteroidRepository
+    private lateinit var logger: Logger
+    private lateinit var worker: RefreshDataWorker
+
+    @Before
+    fun setUp() {
+        repository = mockk(relaxed = true)
+        logger = mockk(relaxed = true)
+        // doWork() only touches the injected repository + logger; the Context and
+        // WorkerParameters are never dereferenced by our override, so relaxed
+        // mocks let us exercise the worker on the JVM without a WorkManager runtime.
+        worker =
+            RefreshDataWorker(
+                appContext = mockk(relaxed = true),
+                params = mockk<WorkerParameters>(relaxed = true),
+                repository = repository,
+                logger = logger,
+            )
+    }
+
+    @Test
+    fun `doWork refreshes the asteroid feed and the picture of the day`() =
+        runTest {
+            // Given a worker run where every refresh succeeds
+            // When doWork executes
+            val result = worker.doWork()
+
+            // Then it purges stale asteroids, refreshes the feed, AND refreshes the
+            // APOD (issue #176: the worker previously skipped the picture of day),
+            // and reports success.
+            coVerify(exactly = 1) { repository.deletePastAsteroids() }
+            coVerify(exactly = 1) { repository.refreshAsteroids() }
+            coVerify(exactly = 1) { repository.refreshPictureOfDay() }
+            assertThat(result).isEqualTo(ListenableWorker.Result.success())
+        }
+
+    @Test
+    fun `doWork still succeeds when the picture-of-day refresh fails internally`() =
+        runTest {
+            // Given refreshPictureOfDay encounters a network problem — the repository
+            // swallows and logs it, so from the worker's view it simply returns
+            coEvery { repository.refreshPictureOfDay() } returns Unit
+
+            // When doWork executes with a healthy asteroid refresh
+            val result = worker.doWork()
+
+            // Then the APOD refresh does not gate the worker's outcome
+            coVerify(exactly = 1) { repository.refreshPictureOfDay() }
+            assertThat(result).isEqualTo(ListenableWorker.Result.success())
+        }
+
+    @Test
+    fun `doWork retries and skips the APOD refresh when the feed throws HttpException`() =
+        runTest {
+            // Given the asteroid feed refresh fails with a retryable HTTP error
+            coEvery { repository.refreshAsteroids() } throws mockk<HttpException>(relaxed = true)
+
+            // When doWork executes
+            val result = worker.doWork()
+
+            // Then the worker retries and never reaches the APOD refresh (existing
+            // retry behavior is preserved after adding the APOD call)
+            assertThat(result).isEqualTo(ListenableWorker.Result.retry())
+            coVerify(exactly = 0) { repository.refreshPictureOfDay() }
+        }
+}


### PR DESCRIPTION
## What

`RefreshDataWorker` refreshed asteroids but never the Picture of the Day. The only caller of `repository.refreshPictureOfDay()` was `MainViewModel.init`, which runs only when the ViewModel is created (a true cold start). When Android keeps the process/ViewModel alive across days, nothing refreshes the cached APOD row in Room — so it stays on yesterday's image until the user force-stops + wipes app data. That's the reported symptom: *"old images don't refresh with new ones until I remove cache and clean data from app."*

## Fix

`RefreshDataWorker.doWork()` now also calls `repository.refreshPictureOfDay()` alongside the asteroid refresh, so the daily worker keeps the APOD current without depending on ViewModel recreation. `refreshPictureOfDay()` already swallows its own network exceptions (logged as `LogEvent.Network.RefreshPictureOfDayFailed`), so it does not interfere with the worker's asteroid-driven `Result.retry()` path.

## Tests

New `RefreshDataWorkerTest` (JVM, mockk):
- `doWork` refreshes the asteroid feed **and** the picture of the day → success.
- `doWork` still succeeds when the APOD refresh fails internally (repo swallows it).
- `doWork` retries and skips the APOD refresh when the feed throws `HttpException` (existing retry behavior preserved).

Local: `testDebugUnitTest` (new tests), `spotlessCheck`, `detekt` all green.

Fixes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)