### PR TITLE
fix(network): retry transient NASA 5xx/timeouts via OkHttp interceptor

### DIFF
--- a/app/src/main/java/com/tarek/asteroidradar/di/NetworkModule.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/di/NetworkModule.kt
@@ -32,6 +32,7 @@ import android.content.Context
 import coil.ImageLoader
 import coil.decode.VideoFrameDecoder
 import com.tarek.asteroidradar.network.AsteroidService
+import com.tarek.asteroidradar.network.RetryInterceptor
 import com.tarek.asteroidradar.util.Constants
 import dagger.Module
 import dagger.Provides
@@ -71,6 +72,11 @@ object NetworkModule {
             .Builder()
             .connectTimeout(NETWORK_TIMEOUT)
             .readTimeout(NETWORK_TIMEOUT)
+            // Issue #178: bounded retry on transient NASA 5xx / connection drops
+            // (the APOD endpoint flaps 503 → 200). Added as an application
+            // interceptor so it sees the final response code and covers both
+            // endpoints + both refresh call sites in one place.
+            .addInterceptor(RetryInterceptor())
             .build()
 
     // Builder order matters: Scalars first matches `String` returns and yields

--- a/app/src/main/java/com/tarek/asteroidradar/network/RetryInterceptor.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/network/RetryInterceptor.kt
@@ -1,0 +1,78 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.network
+
+import okhttp3.Interceptor
+import okhttp3.Response
+import java.io.IOException
+
+// Issue #178: NASA's APIs (especially planetary/apod) intermittently return
+// transient 5xx / drop the connection — observed 503 then 200 on the very next
+// call. A single-attempt fetch leaves the user on the empty-cache placeholder
+// (no photo) until the next cold start. Retrying here on the shared OkHttpClient
+// covers both endpoints and both call sites (MainViewModel + RefreshDataWorker)
+// in one place.
+//
+// 429 (rate limit) and other 4xx are deliberately NOT retried — hammering a
+// rate-limited or client-error request only makes it worse. Both NASA endpoints
+// are idempotent GETs, so replaying the request is safe.
+internal const val DEFAULT_MAX_RETRIES = 3
+internal const val RETRY_BACKOFF_STEP_MS = 300L
+private val RETRYABLE_CODES = setOf(500, 502, 503, 504)
+
+class RetryInterceptor(
+    private val maxRetries: Int = DEFAULT_MAX_RETRIES,
+    // Injected so unit tests can run without real sleeps; production uses
+    // Thread.sleep on OkHttp's dispatcher thread (calls are async/enqueued for
+    // Retrofit suspend functions, so this never blocks the main thread).
+    private val backoffMs: (attempt: Int) -> Long = { attempt -> attempt * RETRY_BACKOFF_STEP_MS },
+    private val sleep: (Long) -> Unit = { millis -> Thread.sleep(millis) },
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        var attempt = 0
+        while (true) {
+            try {
+                val response = chain.proceed(request)
+                if (response.code in RETRYABLE_CODES && attempt < maxRetries) {
+                    // Must close the body before re-issuing or the connection leaks.
+                    response.close()
+                    attempt++
+                    sleep(backoffMs(attempt))
+                    continue
+                }
+                return response
+            } catch (e: IOException) {
+                if (attempt >= maxRetries) throw e
+                attempt++
+                sleep(backoffMs(attempt))
+            }
+        }
+    }
+}

--- a/app/src/test/java/com/tarek/asteroidradar/network/RetryInterceptorTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/network/RetryInterceptorTest.kt
@@ -1,0 +1,146 @@
+/*
+ * MIT License Copyright (c) 2021. Tarek Bohdima
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * This project was submitted by Tarek Bohdima as part of the Android Kotlin
+ * Developer Nanodegree At Udacity. As part of Udacity Honor code, your
+ * submissions must be your own work, hence submitting this project as yours will
+ * cause you to break the Udacity Honor Code and the suspension of your account.
+ * I, the author of the project, allow you to check the code as a reference, but
+ * if you submit it, it's your own responsibility if you get expelled.
+ */
+package com.tarek.asteroidradar.network
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import okhttp3.Interceptor
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Test
+import org.junit.function.ThrowingRunnable
+import java.io.IOException
+
+class RetryInterceptorTest {
+    private val request = Request.Builder().url("https://example.invalid/apod").build()
+
+    // sleep is a no-op so the test never actually waits out the backoff.
+    private val interceptor = RetryInterceptor(maxRetries = 3, sleep = {})
+
+    private fun response(code: Int): Response =
+        Response
+            .Builder()
+            .request(request)
+            .protocol(Protocol.HTTP_1_1)
+            .code(code)
+            .message("test-$code")
+            .body("".toResponseBody(null))
+            .build()
+
+    private fun chainReturning(answer: (Int) -> Response): Interceptor.Chain {
+        val chain = mockk<Interceptor.Chain>(relaxed = true)
+        every { chain.request() } returns request
+        var call = 0
+        every { chain.proceed(any()) } answers { answer(++call) }
+        return chain
+    }
+
+    @Test
+    fun `retries on a retryable 5xx then returns the successful response`() {
+        // Given the endpoint returns 503 once, then 200 (the observed APOD flap)
+        val chain = chainReturning { call -> if (call == 1) response(503) else response(200) }
+
+        // When the request is intercepted
+        val result = interceptor.intercept(chain)
+
+        // Then it retried once and surfaced the 200
+        assertThat(result.code).isEqualTo(200)
+        verify(exactly = 2) { chain.proceed(any()) }
+    }
+
+    @Test
+    fun `retries on IOException then returns the successful response`() {
+        // Given the first attempt drops the connection, the second succeeds
+        val chain = chainReturning { call -> if (call == 1) throw IOException("reset") else response(200) }
+
+        // When the request is intercepted
+        val result = interceptor.intercept(chain)
+
+        // Then the transient IOException was retried and the 200 surfaced
+        assertThat(result.code).isEqualTo(200)
+        verify(exactly = 2) { chain.proceed(any()) }
+    }
+
+    @Test
+    fun `does not retry on 429 rate limit`() {
+        // Given the endpoint rate-limits the request
+        val chain = chainReturning { response(429) }
+
+        // When the request is intercepted
+        val result = interceptor.intercept(chain)
+
+        // Then the 429 is returned as-is with no retry (retrying would worsen it)
+        assertThat(result.code).isEqualTo(429)
+        verify(exactly = 1) { chain.proceed(any()) }
+    }
+
+    @Test
+    fun `does not retry on a 4xx client error`() {
+        // Given a client error
+        val chain = chainReturning { response(404) }
+
+        // When the request is intercepted
+        val result = interceptor.intercept(chain)
+
+        // Then it is returned as-is with no retry
+        assertThat(result.code).isEqualTo(404)
+        verify(exactly = 1) { chain.proceed(any()) }
+    }
+
+    @Test
+    fun `gives up after the retry cap and returns the last 5xx`() {
+        // Given every attempt returns 503
+        val chain = chainReturning { response(503) }
+
+        // When the request is intercepted
+        val result = interceptor.intercept(chain)
+
+        // Then it tried 1 + maxRetries(3) = 4 times and returned the final 503
+        assertThat(result.code).isEqualTo(503)
+        verify(exactly = 4) { chain.proceed(any()) }
+    }
+
+    @Test
+    fun `rethrows the IOException after exhausting retries`() {
+        // Given every attempt throws
+        val chain = chainReturning { throw IOException("always down") }
+
+        // When the request is intercepted, Then the IOException propagates after
+        // 1 + maxRetries(3) = 4 attempts
+        org.junit.Assert.assertThrows(
+            IOException::class.java,
+            ThrowingRunnable { interceptor.intercept(chain) },
+        )
+        verify(exactly = 4) { chain.proceed(any()) }
+    }
+}


### PR DESCRIPTION
## What

NASA's APIs (especially `planetary/apod`) intermittently return transient `5xx` or drop the connection — reproduced on 2026-06-07: `GET planetary/apod` → `503` ("upstream connect error… connection timeout"), then `200` on the next two calls. A single-attempt fetch leaves the user on the empty-cache placeholder (**no photo**) until the next cold start.

## Why the existing retry doesn't cover it

`RefreshDataWorker` already returns `Result.retry()` on `HttpException`, but:
- it's **background-worker-only** — the launch-time refresh (`MainViewModel.init`) has none;
- **APOD never reaches it** — `refreshPictureOfDay()` swallows its exception in the repository, so it never throws to the worker;
- it's a **delayed WorkManager reschedule**, not a retry of the current request.

The #167 timeout bump (10s→20s) doesn't help a *fast* `503` either.

## Fix

`RetryInterceptor` on the shared `OkHttpClient` (`di/NetworkModule.kt`):
- bounded retry (**3**) with linear backoff on `500/502/503/504` and `IOException`;
- **does not** retry `429` (rate limit) or other `4xx` — replaying those is counter-productive;
- both NASA endpoints are idempotent `GET`s, so request replay is safe;
- one place covers **both endpoints + both call sites** (VM + worker);
- `sleep` is injectable so unit tests run without real waits.

## Tests

`RetryInterceptorTest` (mocked `Chain`, real `Response`s): 503→200 retry, IOException→200 retry, no-retry on 429, no-retry on 4xx, gives up after the cap returning the last 503, rethrows IOException after the cap. Local `testDebugUnitTest`, `spotlessCheck`, `detekt` green.

Fixes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)