### PR TITLE
feat(ui): swipe-to-refresh on main screen (reload APOD + asteroids)

### DIFF
--- a/app/src/main/java/com/tarek/asteroidradar/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/ui/main/MainScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -97,6 +98,7 @@ fun MainScreen(
 ) {
     val asteroids by viewModel.asteroids.collectAsStateWithLifecycle()
     val image by viewModel.imageOfTheDay.collectAsStateWithLifecycle()
+    val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     Scaffold(
@@ -104,19 +106,26 @@ fun MainScreen(
         topBar = { MainTopBar(onFilterSelect = viewModel::updateFilters) },
         containerColor = colorResource(R.color.app_background),
     ) { padding ->
-        Column(
+        // Issue #180: pull down anywhere to reload both APOD + asteroids. The
+        // header is the LazyColumn's first item (not a separate Column row) so the
+        // whole screen scrolls and the gesture engages from the very top.
+        PullToRefreshBox(
+            isRefreshing = isRefreshing,
+            onRefresh = viewModel::refresh,
             modifier =
                 Modifier
                     .fillMaxSize()
                     .padding(padding),
         ) {
-            ImageOfTheDayHeader(
-                picture = image,
-                onVideoTap = { url ->
-                    context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
-                },
-            )
             LazyColumn(modifier = Modifier.fillMaxSize()) {
+                item {
+                    ImageOfTheDayHeader(
+                        picture = image,
+                        onVideoTap = { url ->
+                            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
+                        },
+                    )
+                }
                 items(asteroids, key = { it.id }) { asteroid ->
                     AsteroidRow(asteroid = asteroid, onClick = { onAsteroidClick(asteroid) })
                 }

--- a/app/src/main/java/com/tarek/asteroidradar/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/tarek/asteroidradar/ui/main/MainViewModel.kt
@@ -37,6 +37,7 @@ import com.tarek.asteroidradar.repository.AsteroidRepository
 import com.tarek.asteroidradar.repository.AsteroidRepository.AsteroidsFilter
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -71,6 +72,12 @@ class MainViewModel
         private val _filter = MutableStateFlow<AsteroidsFilter>(AsteroidsFilter.STORED)
         val filter: StateFlow<AsteroidsFilter> = _filter.asStateFlow()
 
+        // Issue #180: drives the swipe-to-refresh spinner. True for the duration
+        // of a user-initiated refresh, reset in a finally so a swallowed network
+        // failure still clears the indicator.
+        private val _isRefreshing = MutableStateFlow(false)
+        val isRefreshing: StateFlow<Boolean> = _isRefreshing.asStateFlow()
+
         // Re-evaluates the DAO query whenever the filter flips. WhileSubscribed
         // with a 5s grace handles configuration-change hand-off without
         // resubscribing the underlying Room flow on every recomposition.
@@ -104,6 +111,25 @@ class MainViewModel
                 repository.refreshAsteroids()
             } catch (e: Exception) {
                 logger.log(LogEvent.Network.RefreshAsteroidsFailed(e))
+            }
+        }
+
+        // Issue #180: user-initiated pull-to-refresh. Reloads both surfaces
+        // concurrently (mirroring init) so one gesture recovers the whole screen
+        // — e.g. after a NASA outage left the APOD header empty at launch. Each
+        // refresh swallows its own network error, and coroutineScope waits for
+        // both before the finally clears the spinner.
+        fun refresh() {
+            viewModelScope.launch {
+                _isRefreshing.value = true
+                try {
+                    coroutineScope {
+                        launch { refreshAsteroids() }
+                        launch { refreshPictureOfDay() }
+                    }
+                } finally {
+                    _isRefreshing.value = false
+                }
             }
         }
 

--- a/app/src/test/java/com/tarek/asteroidradar/ui/main/MainViewModelTest.kt
+++ b/app/src/test/java/com/tarek/asteroidradar/ui/main/MainViewModelTest.kt
@@ -39,6 +39,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -152,6 +153,59 @@ class MainViewModelTest {
 
                 cancelAndIgnoreRemainingEvents()
             }
+        }
+
+    @Test
+    fun `refresh toggles isRefreshing true then false`() =
+        runTest(testDispatcher) {
+            // Gate the asteroid refresh so the spinner stays on long enough to
+            // observe — without it the StateFlow would conflate true→false.
+            val gate = CompletableDeferred<Unit>()
+            coEvery { repository.refreshAsteroids() } coAnswers { gate.await() }
+            val viewModel = MainViewModel(repository, logger)
+            advanceUntilIdle()
+
+            viewModel.isRefreshing.test {
+                assertThat(awaitItem()).isFalse() // idle
+
+                viewModel.refresh()
+                advanceUntilIdle()
+                assertThat(awaitItem()).isTrue() // spinner on, refresh in flight
+
+                gate.complete(Unit)
+                advanceUntilIdle()
+                assertThat(awaitItem()).isFalse() // spinner cleared when both finish
+
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+
+    @Test
+    fun `refresh reloads both the picture of the day and the asteroid feed`() =
+        runTest(testDispatcher) {
+            val viewModel = MainViewModel(repository, logger)
+            advanceUntilIdle() // init refreshes each once
+
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            // Once from init + once from the manual refresh = twice each.
+            coVerify(exactly = 2) { repository.refreshAsteroids() }
+            coVerify(exactly = 2) { repository.refreshPictureOfDay() }
+        }
+
+    @Test
+    fun `refresh still clears isRefreshing when a refresh fails`() =
+        runTest(testDispatcher) {
+            // The VM swallows the failure internally, so the finally still runs.
+            coEvery { repository.refreshAsteroids() } throws RuntimeException("boom")
+            val viewModel = MainViewModel(repository, logger)
+            advanceUntilIdle()
+
+            viewModel.refresh()
+            advanceUntilIdle()
+
+            assertThat(viewModel.isRefreshing.value).isFalse()
         }
 
     private companion object {


### PR DESCRIPTION
## What

User-initiated **swipe-to-refresh** on the main screen. Until now the only refresh paths were a cold start (`MainViewModel.init`) or the daily `RefreshDataWorker` — so after a NASA outage or being offline at launch, there was no in-app way to recover an empty/stale APOD header. Pull down to reload **both** the picture of the day and the asteroid feed.

Complements #178 (retry interceptor): retry handles transient blips automatically; this handles longer outages and offline-at-launch.

## Changes

- **`MainViewModel`** — exposes `isRefreshing: StateFlow<Boolean>` and `refresh()`, which sets the flag, runs `refreshAsteroids()` + `refreshPictureOfDay()` concurrently in a `coroutineScope` (mirroring `init`), and clears it in a `finally` so a swallowed network failure still resets the spinner.
- **`MainScreen`** — wraps content in Material3 `PullToRefreshBox(isRefreshing, onRefresh = viewModel::refresh)`. The APOD header moves to be the `LazyColumn`'s first item so the whole screen scrolls and the gesture engages from the very top.

## Tests

`MainViewModelTest` adds:
- `refresh toggles isRefreshing true then false` (Turbine, gated to observe the in-flight state)
- `refresh reloads both the picture of the day and the asteroid feed` (coVerify ×2 — init + manual)
- `refresh still clears isRefreshing when a refresh fails`

Local `testDebugUnitTest`, `spotlessCheck`, `detekt`, `assembleDebug` all green. Emulator-verified: header renders as the first scrollable item and the pull gesture refreshes without crashing.

> New user-visible feature → MINOR bump (v4.1.0) when this ships.

Fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)