### PR TITLE
chore: bump version to v4.1.0-INTERNAL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,8 +70,8 @@ if (googleServicesJson.exists()) {
 // cutting a release. Classifier choices: INTERNAL, ALPHA, BETA, RC, RELEASE.
 // .github/workflows/release.yml greps these names, so don't rename them.
 val versionMajor = 4
-val versionMinor = 0
-val versionPatch = 4
+val versionMinor = 1
+val versionPatch = 0
 val versionClassifier = "INTERNAL"
 
 // versionCode formula uses minSdk as a high digit so a future minSdk bump


### PR DESCRIPTION
Bumps `versionMinor` 0 → 1, `versionPatch` 4 → 0 → **v4.1.0-INTERNAL** (versionCode 26040004 → 26040100).

Earns the MINOR bump via the swipe-to-refresh feature (#181), bundled with the two PATCH fixes that shipped in the same cycle:
- #177 — daily worker refreshes the APOD
- #179 — retry interceptor for transient NASA 5xx/timeouts
- #181 — swipe-to-refresh

Required before tagging `v4.1.0-INTERNAL` (the release workflow validates the tag against these fields).

Refs #176 #178 #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)