### PR TITLE
build: bump compileSdk 36 → 37

### DIFF
--- a/benchmark/build.gradle.kts
+++ b/benchmark/build.gradle.kts
@@ -33,7 +33,7 @@ plugins {
 
 android {
     namespace = "com.tarek.asteroidradar.benchmark"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         // Macrobenchmark requires API 23+; baseline-profile generation needs

--- a/build-logic/convention/src/main/kotlin/asteroidradar.android.application.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/asteroidradar.android.application.gradle.kts
@@ -47,10 +47,11 @@ plugins {
 }
 
 extensions.configure<ApplicationExtension> {
-    // SDK 36 (Android 16) is the new floor for AndroidX 2.10/2.9 lifecycle and
-    // navigation; bumped alongside the Phase 13b group bump. minSdk stays at
-    // 26 (no breaking-for-users bump per the SemVer table in CLAUDE.md).
-    compileSdk = 36
+    // SDK 37 is the new floor for AndroidX Lifecycle 2.11 and Hilt 1.4, whose
+    // AAR metadata requires compiling against API 37. targetSdk stays 36 and
+    // minSdk stays 26 (no breaking-for-users bump per the SemVer table in
+    // CLAUDE.md) — this bump only raises the compile-time API floor.
+    compileSdk = 37
 
     defaultConfig {
         minSdk = 26


### PR DESCRIPTION
## Summary

Bumps `compileSdk` from 36 → 37 in the application convention plugin and the benchmark module. AndroidX Lifecycle 2.11 and Hilt 1.4 ship AAR metadata requiring dependents to compile against API 37, so this raises the compile-time floor to unblock the androidx group Dependabot PR (#206).

`targetSdk` stays **36** and `minSdk` stays **26** — this is a compile-time-only bump with no runtime-behavior or supported-device change.

## Verification

Run locally against `android-37.0`:

- `:app:checkReleaseAarMetadata` ✅
- `:app:checkBenchmarkReleaseAarMetadata` ✅
- `assembleDebug` ✅ (`BUILD SUCCESSFUL`)
- AGP 9.2.1 emitted **no** unsupported-compileSdk warning, so no `android.suppressUnsupportedCompileSdk` entry in `gradle.properties` was needed.

Fixes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)