### PR TITLE
chore(deps): bump kotlin 2.4.0→2.4.10 and kover 0.9.8→0.9.9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 [versions]
 agp = "9.3.1"
-kotlin = "2.4.0"
+kotlin = "2.4.10"
 # KSP version format is `<kotlin>-<ksp-impl>` since KSP2 (>= 2.0) — must match
 # the Kotlin compiler version exactly on the leading segment. Pinned to NIA's
 # 2.3.4 (Kotlin 2.3.0 baseline) rather than 2.3.7, which is the bleeding edge
@@ -102,7 +102,7 @@ composeRules = "0.6.3"
 dependencyAnalysis = "3.18.0"
 detekt = "1.23.8"
 # Kover 0.9.x supports Kotlin 2.0+; aligned with the project's Kotlin pin.
-kover = "0.9.8"
+kover = "0.9.9"
 ktlint = "1.5.0"
 spotless = "8.9.0"
 


### PR DESCRIPTION
Supersedes #218 (kotlin-and-coroutines group), which conflicted with the AGP 9.3.1 / KSP 2.3.11 bump (#232) on adjacent `libs.versions.toml` lines and didn't auto-rebase. Identical version targets, applied cleanly on current master.

- `kotlin` 2.4.0 → 2.4.10
- `kover` 0.9.8 → 0.9.9

Completes the toolchain batch (AGP 9.3.1, KSP 2.3.11, Kotlin 2.4.10). Master-time release smoke to follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)