### PR TITLE
chore: bump version to v4.1.1-INTERNAL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,7 +71,7 @@ if (googleServicesJson.exists()) {
 // .github/workflows/release.yml greps these names, so don't rename them.
 val versionMajor = 4
 val versionMinor = 1
-val versionPatch = 0
+val versionPatch = 1
 val versionClassifier = "INTERNAL"
 
 // versionCode formula uses minSdk as a high digit so a future minSdk bump


### PR DESCRIPTION
Patch bump for the 2026-08 dependency + toolchain batch. Dependency + toolchain only — no user-facing change, so PATCH per the SemVer table.

- `versionPatch` 0 → 1 → **v4.1.1-INTERNAL** (versionCode 26040101)

Covers: AGP 9.3.1, Kotlin 2.4.10, KSP 2.3.11, compileSdk 37, kover 0.9.9, dependencyAnalysis 3.18.0, AndroidX group (Compose BOM / Lifecycle 2.11 / Hilt 1.4 / ConstraintLayout / macrobenchmark), Firebase BoM (Crashlytics 20.1.0), org.json, spotless, compose-rules detekt, and CI action bumps.

**Pre-tag smoke (done):** `assembleRelease` + R8 + v2 signing, then install + clean cold launch on Pixel 7 Pro (API 33) — MainActivity displayed, Crashlytics init, no crash/ANR.

Tag `v4.1.1-INTERNAL` to be pushed after this merges (release workflow validates tag == build.gradle.kts version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)